### PR TITLE
Render does not trigger after card is loaded

### DIFF
--- a/map-card.js
+++ b/map-card.js
@@ -27,6 +27,10 @@ class MapCard extends LitElement {
 
   firstUpdated() {
     this.map = this._setupMap();    
+    // force a render when the page is done loading
+    setTimeout(() => {
+      this.render();
+    });
   }
   
   render() {    


### PR DESCRIPTION
Greetings,
I'm no expert of lit-element, but it seems that on some instances the render() method does not fire a second time after the page load, leaving the card like this until user interaction (mainly because of the missing map.invalidateSize() call ) :
![Screenshot 2024-03-15 105158](https://github.com/nathan-gs/ha-map-card/assets/20266095/76d03eb8-e749-4dce-815d-e8db9e6972e1)

The issue seems to arise only the first time the dashboard with the map card is loaded, without error output.
I've solved the issue with a quick hack, but it would be great if you can look into it.