### PR TITLE
Fix card being disposed when reloading the page or switching between dashboards

### DIFF
--- a/map-card.js
+++ b/map-card.js
@@ -246,6 +246,13 @@ class MapCard extends LitElement {
     return this.config.card_size;
   }
 
+    connectedCallback() {
+      super.connectedCallback();
+      if (this.shadowRoot.querySelector('#map')) {
+        this.firstUpdated();
+      }
+    }
+
   disconnectedCallback() {
     super.disconnectedCallback();
     if (this.map) {

--- a/map-card.js
+++ b/map-card.js
@@ -27,6 +27,10 @@ class MapCard extends LitElement {
 
   firstUpdated() {
     this.map = this._setupMap();    
+    // force a render when the page is done loading
+    setTimeout(() => {
+      this.render();
+    });
   }
   
   render() {    

--- a/map-card.js
+++ b/map-card.js
@@ -166,8 +166,8 @@ class MapCard extends LitElement {
 
     const resizeObserver = new ResizeObserver(entries => {
       for (let entry of entries) {
-        if (entry.target === this.map.getContainer()) {          
-          this.map.invalidateSize();
+        if (entry.target === this.map?.getContainer()) {
+          this.map?.invalidateSize();
         }
       }
     });
@@ -247,6 +247,7 @@ class MapCard extends LitElement {
   }
 
   disconnectedCallback() {
+    super.disconnectedCallback();
     if (this.map) {
       this.map.remove();
       this.map = undefined;

--- a/map-card.js
+++ b/map-card.js
@@ -246,12 +246,13 @@ class MapCard extends LitElement {
     return this.config.card_size;
   }
 
-    connectedCallback() {
-      super.connectedCallback();
-      if (this.shadowRoot.querySelector('#map')) {
-        this.firstUpdated();
-      }
+  connectedCallback() {
+    super.connectedCallback();
+    // Reinitialize the map when the card gets reloaded but it's still in view
+    if (this.shadowRoot.querySelector('#map')) {
+      this.firstUpdated();
     }
+  }
 
   disconnectedCallback() {
     super.disconnectedCallback();


### PR DESCRIPTION
This pull request provides a fix for issue #13 and addresses scenarios involving early component disconnections (such as drag and drop events, swap between dashboards containing the same card and HA dashboard "edit ui" exit).

The best choice here should be to always initialize the map (and the resize observer) inside the `connectedCallback`, so it gets always re-initialized after being disposed. However in our case this is not feasible because leaflet needs an element hook.
The official implementation accomplish the task by [injecting the map element directly on the shadow dom](https://github.com/home-assistant/frontend/blob/dev/src/components/map/ha-map.ts#L177), i've tried mimiking it, but to no avail (if you switch dashboards, the newly generated shadow dom does not render correctly).

I have added a check in `connectedCallback` to see if the map element is loaded. If it is, both the map element and the resizeObserver are re-initialized. This way we can both initialize the map normally on `firstUpdated` and keep the memory leak fix after the card unload.
