### PR TITLE
fullscreen card on panel view

### DIFF
--- a/map-card.js
+++ b/map-card.js
@@ -340,11 +340,7 @@ class MapCard extends LitElement {
   }
 
   static get styles() {
-    return css`    
-      :host {
-        display:block;
-        height: 100%;
-      }        
+    return css`       
       #map {
         height: 100%;
         border-radius: var(--ha-card-border-radius,12px);

--- a/map-card.js
+++ b/map-card.js
@@ -53,8 +53,8 @@ class MapCard extends LitElement {
 
     return html`
             <link rel="stylesheet" href="/static/images/leaflet/leaflet.css">
-            <ha-card header="${this._getTitle()}">
-                <div id="map" style="height: ${this._getMapHeight()}px"></div>
+            <ha-card header="${this._getTitle()}" style="height: 100%">
+                <div id="map" style="min-height: ${this._getMapHeight()}px"></div>
             </ha-card>
         `;
   }
@@ -342,9 +342,11 @@ class MapCard extends LitElement {
   static get styles() {
     return css`    
       :host {
-          display:block;     
+        display:block;
+        height: 100%;
       }        
       #map {
+        height: 100%;
         border-radius: var(--ha-card-border-radius,12px);
       }
       .leaflet-pane {


### PR DESCRIPTION
Adds the feature requested on #11 .

This way we can keep intact the current `card_size` configuration behaviour, while providing a default full-screen card in panel mode dashboards.