### PR TITLE
Add ability to set custom picture for entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Either the name of the `entity` or:
 |-----------------------|---------------------------------------|-----------------------------------------------------------------------------------------------|
 | `entity`              |                                       | The entity id                                                                                 |
 | `display`             | `marker`                              | `icon`, `state` or `marker`. `marker` will display the picture if available                   |
-| `picture`             |                                     	| Set a custom picture to use on the marker.                                            |
-| `size`                | 48                                    | Size of the icon                                                |
+| `picture`             |                                     	| Set a custom picture to use on the marker.                                           			|
+| `size`                | 48                                    | Size of the icon                                               								|
 | `color`               | Random Color                          | Can defined as `red`, `rgb(255,0,0)`, `rgba(255,0,0,0.1)`, `#ff0000`, `var(--red-color)`      |
 | `css`                 | `text-align: center; font-size: 60%;` | CSS for the marker (only for `state` and `marker`)                                            |
 | `history_start`       |                                       | Will inherit from map config if not set.                                                      |

--- a/map-card.js
+++ b/map-card.js
@@ -42,7 +42,8 @@ class EntityConfig {
   fallbackY;
   /** @type {String} */
   css;
-  
+  /** @type {String} */
+  picture;
 
   constructor(config) {
     this.id = (typeof config === 'string' || config instanceof String)? config : config.entity;
@@ -58,6 +59,7 @@ class EntityConfig {
     this.fallbackX = config.fallback_x;
     this.fallbackY = config.fallback_y;
     this.css = config.css ?? "text-align: center; font-size: 60%;";
+    this.picture = config.picture ?? null;
   }
 
   get hasHistory() {
@@ -149,7 +151,8 @@ class MapConfig {
   tileLayers;
   /** @type {TileLayerConfig} */
   tileLayer;
-
+  /** @type {Int} */
+  map_height;
 
   constructor(inputConfig) {
     this.title = inputConfig.title;
@@ -158,6 +161,7 @@ class MapConfig {
     this.y = inputConfig.y;
     this.zoom = this._setConfigWithDefault(inputConfig.zoom, 12);
     this.cardSize = this._setConfigWithDefault(inputConfig.card_size, 5);
+    this.map_height = inputConfig.map_height;
     
     this.entities = (inputConfig["entities"] ? inputConfig.entities : []).map((ent) => {
       return new EntityConfig(ent);
@@ -196,6 +200,9 @@ class MapConfig {
 
   /** @returns {Int} */
   get mapHeight() {
+    if(this.map_height){
+      return this.map_height;
+    }
     if (this.hasTitle) {
       return (this.cardSize * 50) + 20 - 76 - 2;
     } else {
@@ -559,12 +566,16 @@ class MapCard extends LitElement {
         passive,
         icon,
         radius,
-        entity_picture: entityPicture,
+        entity_picture,
         gps_accuracy: gpsAccuracy,
         friendly_name
       } = stateObj.attributes;
       const state = hass.formatEntityState(stateObj);
-      const picture = entityPicture ? hass.hassUrl(entityPicture) : null;
+
+      // If no configured picture, fallback to entity picture
+      let picture = configEntity.picture ?? entity_picture;
+      // Skip if neither found and return null
+      picture = picture ? hass.hassUrl(picture) : null;
 
       const entity = new Entity(configEntity, latitude, longitude, icon, friendly_name, state, picture);      
       entity.marker.addTo(map);

--- a/map-card.js
+++ b/map-card.js
@@ -152,7 +152,7 @@ class MapConfig {
   /** @type {TileLayerConfig} */
   tileLayer;
   /** @type {Int} */
-  map_height;
+  mapHeight;
 
   constructor(inputConfig) {
     this.title = inputConfig.title;
@@ -161,7 +161,7 @@ class MapConfig {
     this.y = inputConfig.y;
     this.zoom = this._setConfigWithDefault(inputConfig.zoom, 12);
     this.cardSize = this._setConfigWithDefault(inputConfig.card_size, 5);
-    this.map_height = inputConfig.map_height;
+    this.mapHeight = inputConfig.map_height;
     
     this.entities = (inputConfig["entities"] ? inputConfig.entities : []).map((ent) => {
       return new EntityConfig(ent);
@@ -200,8 +200,8 @@ class MapConfig {
 
   /** @returns {Int} */
   get mapHeight() {
-    if(this.map_height){
-      return this.map_height;
+    if(this.mapHeight){
+      return this.mapHeight;
     }
     if (this.hasTitle) {
       return (this.cardSize * 50) + 20 - 76 - 2;


### PR DESCRIPTION
Hi @nathan-gs,
Hope these look okay, two  minor quality of life additions. 

* Add `picture` property to entities. Setting this with a URL will override the default photo for markers.
* ~Add `map_height` (int) to card. This sets map min-height and can be used to override/force a preferred height for the map itself.~