### PR TITLE
Provide the ability to explore location history data using HA date range.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ y: 3.652
 |--------------------------|------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------|
 | `x`                      |                                                                                                                              | Longitude                                    |
 | `y`                      |                                                                                                                              | Latitude                                     |
+| `history_start`          |                                       																						  | Examples: `2022-03-01T12:00:00Z`, `5 hours ago`  |
+| `history_end`            | `now`                                 																						  | Examples: `2022-03-01T18:00:00Z`, `2 hours ago`, `now` |
 | `focus_entity`           |                                                                                                                              | Entity to focus on (instead of X & Y)        |
 | `title`                  |                                                                                                                              | If empty, don't show a title                 |
 | `zoom`                   | 12                                                                                                                           | The zoom level                               |
@@ -57,9 +59,12 @@ y: 3.652
 | `tile_layer_url`         | https://tile.openstreetmap.org/{z}/{x}/{y}.png                                                                               | Override the default map source              |
 | `tile_layer_attribution` | &amp;copy; &lt;a href&#x3D;&quot;http:&#x2F;&#x2F;www.openstreetmap.org&#x2F;copyright&quot;&gt;OpenStreetMap&lt;&#x2F;a&gt; | Set the correct map attribution              |
 | `tile_layer_options` | {}                                                                                                                               | The `options` for the default [TileLayer](https://leafletjs.com/reference.html#tilelayer) |
+| `history_date_selection` | false                                                                                                                        | Will link with a `energy-date-selection` on the page to provide a user controllable date range selector |
 
 
 If `x` & `y` or `focus_entity` is not set it will take the lat/long from the __first entity__.
+
+If using `history_date_selection:true`, please ensure a component with the template `type: energy-date-selection` has been added to the page. If this is set top level `history_start`/`history_end` configuration is ignored in favour of the selected date ranges. `history_start` will continue to override the selected date range and global settings.
 
 ###### Entity options
 
@@ -69,8 +74,8 @@ Either the name of the `entity` or:
 | `entity`              |                                       | The entity id                                                                                 |
 | `display`             | `marker`                              | `icon`, `state` or `marker`. `marker` will display the picture if available                   |
 | `size`                | 24                                    | Size of the icon (not supported for `marker`)                                                 |
-| `history_start`       |                                       | Examples: `2022-03-01T12:00:00Z`, `5 hours ago`                                               |
-| `history_end`         | `now`                                 | Examples: `2022-03-01T18:00:00Z`, `2 hours ago`, `now`                                        |
+| `history_start`       |                                       | Will inherit from map config if not set.                                               |
+| `history_end`         | `now`                                 | Will inherit from map config if not set.                                           |
 | `history_line_color`  | Random Color                          | Can defined as `red`, `rgb(255,0,0)`, `rgba(255,0,0,0.1)`, `#ff0000`, `var(--red-color)`      |
 | `history_show_lines`  | true                                  | Show the path                                                                                 |
 | `history_show_dots`   | true                                  | Show little dots on the path                                                                  |

--- a/map-card.js
+++ b/map-card.js
@@ -493,7 +493,7 @@ class HaDateRangeService {
       if (energyCollection) {
         complete(energyCollection);
       } else if (Date.now() - this.pollStartAt > this.TIMEOUT) {
-        new Error('Unable to connect to energy date selector. Make sure to add a `type: energy-date-selection` card to this screen.');
+        console.error('Unable to connect to energy date selector. Make sure to add a `type: energy-date-selection` card to this screen.');
       } else {
         setTimeout(() => this.getEnergyDataCollectionPoll(complete), 100);
       }


### PR DESCRIPTION
Hi @nathan-gs,

Slightly chunkier one, but is the idea that set me off looking for a custom map card to begin with.

By setting `history_date_selection` to true, the card will attempt to link with a `type: energy-date-selection` on the same page (in the same way sankey charts and other energy dashboard components do) to provide users with an easy way to navigate through the historical location data  -  both looking a time ranges and specific dates.

![image](https://github.com/nathan-gs/ha-map-card/assets/887397/1bdd29f3-f71e-47f3-8100-002fef6b8532)

Although its a bit odd the component is `energy-date-selection`, HA don't have a more generic version and this one provides pretty much my full feature Wishlist out of the box in terms of exploring history.

As a rundown of key changes:
* `history_start` and `history _end` can now be set on card level and will automatically be inherited by any entities that don't define their own start/ends
* Your date convert has been moved to a Util class `HaMapUtilities`
* Each entities history is now held in its own LayerGroup (for easier cleaning up)
* I've added a new service `HaDateRangeService` which deals with linking up with  `energy-date-selection` when needed.
* If  `energy-date-selection` is on, history_start/end at card level will be ignored, but individual entities can still override this.
* Attempted to update readme to explain setup for the date range stuff as can be a bit more involved.

Please let me know if you have any thoughts/suggestions on how this all works 😄 

Cheers,
Carl
