### PR TITLE
Restore ability to set size on entities markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Either the name of the `entity` or:
 |-----------------------|---------------------------------------|-----------------------------------------------------------------------------------------------|
 | `entity`              |                                       | The entity id                                                                                 |
 | `display`             | `marker`                              | `icon`, `state` or `marker`. `marker` will display the picture if available                   |
-| `size`                | 24                                    | Size of the icon (not supported for `marker`)                                                 |
+| `size`                | 48                                    | Size of the icon                                                |
 | `history_start`       |                                       | Examples: `2022-03-01T12:00:00Z`, `5 hours ago`                                               |
 | `history_end`         | `now`                                 | Examples: `2022-03-01T18:00:00Z`, `2 hours ago`, `now`                                        |
 | `history_line_color`  | Random Color                          | Can defined as `red`, `rgb(255,0,0)`, `rgba(255,0,0,0.1)`, `#ff0000`, `var(--red-color)`      |

--- a/map-card.js
+++ b/map-card.js
@@ -47,7 +47,7 @@ class EntityConfig {
   constructor(config) {
     this.id = (typeof config === 'string' || config instanceof String)? config : config.entity;
     this.display = config.display ? config.display : "marker";
-    this.size = config.size ? config.size : 24;
+    this.size = config.size ? config.size : 48;
     this.historyStart = config.history_start ? this._convertToAbsoluteDate(config.history_start) : null;
     this.historyEnd = this._convertToAbsoluteDate(config.history_end ?? "now");
     this.historyLineColor = config.history_line_color ?? this._generateRandomColor();
@@ -389,9 +389,10 @@ class Entity {
               picture ?? ""
             }"
             style="${this.config.css}"
+            size="${this.config.size}"
           ></map-card-entity-marker>
         `,
-        iconSize: [48, 48],
+        iconSize: [this.config.size, this.config.size],
         className: "",
       }),
       title: this.id,
@@ -717,7 +718,8 @@ class MapCardEntityMarker extends LitElement {
       'title': {type: String, attribute: 'title'},
       'picture': {type: String, attribute: 'picture'},
       'icon': {type: String, attribute: 'icon'},
-      'color': {type: String, attribute: 'color'}
+      'color': {type: String, attribute: 'color'},
+      'size': {type: Number}
     };
   }
 
@@ -725,7 +727,7 @@ class MapCardEntityMarker extends LitElement {
    return html`
       <div
         class="marker ${this.picture ? "picture" : ""}"
-        style="border-color: ${this.color}"
+        style="border-color: ${this.color}; height: ${this.size}px; width: ${this.size}px;"
         @click=${this._badgeTap}
       >
         ${this._inner()}


### PR DESCRIPTION
Fixes https://github.com/nathan-gs/ha-map-card/issues/38

I've updated the new Marker to play nice with the entity size property. Hopefully this sorts #38.
So far as I can tell it works with all entity types as well.

Key changes:
- Update `map-card-entity-marker` to allow size prop
- Change to new default icon size of 48
- Set size in css & icon