### PR TITLE
Add ability to set Marker colour.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Either the name of the `entity` or:
 | `entity`              |                                       | The entity id                                                                                 |
 | `display`             | `marker`                              | `icon`, `state` or `marker`. `marker` will display the picture if available                   |
 | `size`                | 24                                    | Size of the icon (not supported for `marker`)                                                 |
+| `color`               | Random Color                          | Can defined as `red`, `rgb(255,0,0)`, `rgba(255,0,0,0.1)`, `#ff0000`, `var(--red-color)`      |
 | `history_start`       |                                       | Examples: `2022-03-01T12:00:00Z`, `5 hours ago`                                               |
 | `history_end`         | `now`                                 | Examples: `2022-03-01T18:00:00Z`, `2 hours ago`, `now`                                        |
 | `history_line_color`  | Random Color                          | Can defined as `red`, `rgb(255,0,0)`, `rgba(255,0,0,0.1)`, `#ff0000`, `var(--red-color)`      |

--- a/map-card.js
+++ b/map-card.js
@@ -42,7 +42,8 @@ class EntityConfig {
   fallbackY;
   /** @type {String} */
   css;
-  
+  /** @type {String} */
+  color;
 
   constructor(config) {
     this.id = (typeof config === 'string' || config instanceof String)? config : config.entity;
@@ -50,7 +51,10 @@ class EntityConfig {
     this.size = config.size ? config.size : 24;
     this.historyStart = config.history_start ? this._convertToAbsoluteDate(config.history_start) : null;
     this.historyEnd = this._convertToAbsoluteDate(config.history_end ?? "now");
-    this.historyLineColor = config.history_line_color ?? this._generateRandomColor();
+    // If historyLineColor not set, inherit icon color
+    this.color = config.color ?? this._generateRandomColor();
+    this.historyLineColor = config.history_line_color ?? this.color;
+
     this.historyShowDots = config.history_show_dots ?? true;
     this.historyShowLines = config.history_show_lines ?? true;
     this.fixedX = config.fixed_x;
@@ -388,6 +392,7 @@ class Entity {
             picture="${
               picture ?? ""
             }"
+            color="${this.config.color}"
             style="${this.config.css}"
           ></map-card-entity-marker>
         `,


### PR DESCRIPTION
Sorry to keep inundating you with PRs. I have a combined branch with all my changes together if it'd be more useful for me to PR that directly, rather than the minor features.

This one allows marker colour to be set on entities. The history will default to using the same one.