### PR TITLE
Handle missing/unknown entities better.

### DIFF
--- a/map-card.js
+++ b/map-card.js
@@ -560,8 +560,8 @@ class MapCard extends LitElement {
     
     if (this.map) {
       if(!this.hasError && this.hadError) {
-        L.control.attribution().removeAttribution("Error found, check Console").addTo(this.map);
-        L.control.attribution().removeAttribution("Error found in first run, check Console").addTo(this.map);
+        HaMapUtilities.removeWarningOnMap(this.map, "Error found, check Console");
+        HaMapUtilities.removeWarningOnMap(this.map, "Error found in first run, check Console");
         this.hadError = false;
       }
 
@@ -596,7 +596,7 @@ class MapCard extends LitElement {
           this.hasError = true;
           this.hadError = true;
           console.error(e);
-          L.control.attribution().addAttribution("Error found in first run, check Console").addTo(this.map);                   
+          HaMapUtilities.renderWarningOnMap(this.map, "Error found in first run, check Console");
         }
         this.firstRenderWithMap = false;
       }
@@ -618,7 +618,7 @@ class MapCard extends LitElement {
           this.hasError = true;
           this.hadError = true;
           console.error(e);
-          L.control.attribution().addAttribution("Error found, check Console").addTo(this.map);
+          HaMapUtilities.renderWarningOnMap(this.map, "Error found, check Console");
         }
       });
   
@@ -935,9 +935,12 @@ class HaMapUtilities {
 
   // Show error message
   static renderWarningOnMap(map, message){
-    L.control.attribution().addAttribution(message).addTo(map);
+    L.control.attribution({prefix:'⚠️'}).addAttribution(message).addTo(map);
   }
-
+  // Hide error message
+  static removeWarningOnMap(map, message){
+    L.control.attribution({prefix:'⚠️'}).removeAttribution(message).addTo(map);
+  }
 }
 
 if (!customElements.get("map-card")) {

--- a/map-card.js
+++ b/map-card.js
@@ -634,7 +634,6 @@ class MapCard extends LitElement {
 
   _firstRender(map, hass, entities) {
     console.log("First Render with Map object, resetting size.")
-    console.log(entities);
     return entities.map((configEntity) => {
       const stateObj = hass.states[configEntity.id];
       const {

--- a/map-card.js
+++ b/map-card.js
@@ -463,6 +463,8 @@ class HaDateRangeService {
   TIMEOUT = 10000;
   listeners = [];
   pollStartAt;
+
+  connection;
   
   constructor(hass) {
     // Store ref to HASS
@@ -478,8 +480,7 @@ class HaDateRangeService {
 
   // Once connected, subscribe to date range changes
   onConnect(energyCollection) {
-
-    energyCollection.subscribe(collection => { 
+    this.connection = energyCollection.subscribe(collection => { 
         console.debug("HaDateRangeService: date range changed");
         this.listeners.forEach(function(callback) { 
           callback(collection); 
@@ -509,6 +510,13 @@ class HaDateRangeService {
   // Register listener
   onDateRangeChange(method) {
     this.listeners.push(method);
+  }
+
+  disconnect(){
+     this.listeners = [];
+     // Unsub
+     this.connection();
+     console.debug("HaDateRangeService: Disconnecting");
   }
 }
 
@@ -740,6 +748,7 @@ class MapCard extends LitElement {
 
     this.resizeObserver?.unobserve(this);
     this.historyService?.unsubscribe();
+    this.dateRangeService.disconnect();
   }
 
   /** @returns {[Double, Double]} */


### PR DESCRIPTION
Good morning.

Attempt to improve on https://github.com/nathan-gs/ha-map-card/issues/36

If an entity has issues loading, now only that specific entity gets skipped and a warning is shown on the map. For example an entity without a lat/lng or fallback is used.

Also fixes `focus_entity` behavior.