### PR TITLE
[Hotfix] Missing `import` for HaMapUtilities in MapConfig.

### DIFF
--- a/src/configs/MapConfig.js
+++ b/src/configs/MapConfig.js
@@ -1,6 +1,7 @@
 import EntityConfig from "./EntityConfig.js"
 import TileLayerConfig from "./TileLayerConfig.js"
 import WmsLayerConfig from "./WmsLayerConfig.js"
+import HaMapUtilities from "../util/HaMapUtilities.js"
 
 export default class MapConfig {
   /** @type {String} */


### PR DESCRIPTION
Apologies, looks like I missed an import when I cleaned up some I thought were unused.
Fixes https://github.com/nathan-gs/ha-map-card/issues/50