### PR TITLE
Add card to main card list so it can be selected via the "Add Card menu

### DIFF
--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -156,8 +156,8 @@ export default class MapCard extends LitElement {
             // Provide summary of config for each entities history
             Logger.debug(historyDebug);
 
-            // Render history now if this isn't dynamic.
-            if (ent.config.historyStart && ent.config.historyEnd){
+            // Render history now if start is fixed and end isn't dynamic
+            if (ent.config.historyStart && !ent.config.historyEndEntity) {
               ent.setupHistory(this.historyService, ent.config.historyStart, ent.config.historyEnd);
             }
             
@@ -336,6 +336,23 @@ export default class MapCard extends LitElement {
       throw new Error(`Entity ${entityId} has no longitude & latitude.`);
     }
     return [entity.attributes.latitude, entity.attributes.longitude];
+  }
+
+  static getStubConfig(hass) {
+    // Find a power entity for default
+    const sampleEntities = Object.keys(hass.states).filter(
+      (entityId) => {
+        const entity = hass.states[entityId];
+        return (entity.state && entity.attributes && entity.attributes.latitude && entity.attributes.longitude); 
+      }  
+    );
+
+    // Sample config
+    return {
+      type: 'custom:map-card',
+      history_start: '24 hours ago',
+      entities: sampleEntities
+    };
   }
 
   static get styles() {

--- a/src/index.js
+++ b/src/index.js
@@ -9,3 +9,12 @@ if (!customElements.get("map-card")) {
     'color: orange; font-weight: bold; background: black'
   )
 }
+
+// Register card so that it appears in the "Card Picker"
+window.customCards.push({
+    name: 'Map Card',
+    description: 'A more powerful Map Card for Home Assistant',
+    type: 'map-card',
+    preview: true,
+    documentationURL: `https://github.com/nathan-gs/ha-map-card`,
+});


### PR DESCRIPTION
Only just realised the card doesn't actually show in the "add card" menu. I've made a few tweaks to fix this.
* Card is now registered with the "add card" menu including a preview
* Basic stub is setup, so defaults to including all entities with lng/lat info.
* Fixed a bug where history didn't work if you only set a history_start (as history_end defaults to null)

![image](https://github.com/nathan-gs/ha-map-card/assets/887397/6acfff3d-3b59-487e-9b19-c370858c19f2)
