### PR TITLE
History for WMS & TileLayers

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ Either the name of the `entity` or:
 | `fallback_x`          |                                       | If the latitude/longitude is missing, use these fixed attributes                              |
 | `fallback_y`          |                                       | If the latitude/longitude is missing, use these fixed attributes                              |
 
+#### WMS and tile_layers options
+
+| name      | note                                                                                                                                                        |
+|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `url`     | The url of the layer                                                                                                                                        |
+| `options` | The leaflet layer [WMS options](https://leafletjs.com/reference.html#tilelayer-wms) or [Tile Layer options](https://leafletjs.com/reference.html#tilelayer) |
+| `history` | If the layer or WMS supports a date or time option. Set history to the name of this property. The `history_start` value, state or date range picker will then set this property on the layer and update it as necessary. |
+
+
+
 #### History options.
 
 If `history_date_selection:true`, any entities that do not define their own `history_start` and `history_end` configuration will be automatically linked to this. Please ensure a card of `type: energy-date-selection`  exists on the page before enabling this.
@@ -105,13 +115,20 @@ history_start:
 Each entity can individually override the base config by setting its own `history_start`/`history_end`, using any of the options above.
 Any entity without its own settings will inherit the map level config.
 
+##### Advanced WMS/Tile layer options.
+More complex use of the WMS/Tile history property can be configured within the history property of the layer.
+* `property` is the option this should control
+* `source` defaults to auto (which means it will inherit from the main map settings). Set this to a date or number entity if this is different.
+* `suffix` days ago/weeks ago as with other history entities
+* `force_midnight` some WMS/Tile layers only work if the date is set as midnight.
 
-#### WMS and tile_layers options
-
-| name      | note                                                                                                                                                        |
-|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `url`     | The url of the layer                                                                                                                                        |
-| `options` | The leaflet layer [WMS options](https://leafletjs.com/reference.html#tilelayer-wms) or [Tile Layer options](https://leafletjs.com/reference.html#tilelayer) |
+```
+  history:
+    property: time
+    source: input_number.test_number_value
+    suffix: months ago
+    force_midnight: true
+```
 
 
 #### Extra Tile Layers

--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -364,7 +364,7 @@ export default class MapCard extends LitElement {
       this.linkedEntityService.onStateChange(
         l.historySource, // Must provide a date.
         (newState) => {
-            swapLayer(newState);
+            swapLayer(HaMapUtilities.convertToAbsoluteDate(newState));
         }
       );
     }

--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -370,7 +370,8 @@ export default class MapCard extends LitElement {
       this.linkedEntityService.onStateChange(
         l.historySource, // Must provide a date.
         (newState) => {
-            updateLayer(HaMapUtilities.convertToAbsoluteDate(newState));
+          const date = HaMapUtilities.getEntityHistoryDate(newState, l.historySourceSuffix);
+          updateLayer(date);
         }
       );
     }

--- a/src/configs/EntityConfig.js
+++ b/src/configs/EntityConfig.js
@@ -66,7 +66,7 @@ export default class EntityConfig {
     // If start is an entity, setup entity config
     if (HaMapUtilities.isHistoryEntityConfig(historyStart)) {
       this.historyStartEntity = historyStart['entity'] ?? historyStart;
-      this.historyStartEntitySuffix = historyStart['suffix'] ??  (!isNaN(this.historyStartEntity) ? 'hours ago' : '');
+      this.historyStartEntitySuffix = historyStart['suffix'];
     } else {
         this.historyStart = historyStart ? HaMapUtilities.convertToAbsoluteDate(historyStart) : null;
     }
@@ -74,7 +74,7 @@ export default class EntityConfig {
     // If end is an entity, setup entity config
     if (HaMapUtilities.isHistoryEntityConfig(historyEnd)) {
       this.historyEndEntity = historyEnd['entity'] ?? historyEnd;
-      this.historyEndEntitySuffix = historyEnd['suffix'] ?? (!isNaN(this.historyEndEntity) ? 'hours ago' : '');
+      this.historyEndEntitySuffix = historyEnd['suffix'];
     } else {
       this.historyEnd = HaMapUtilities.convertToAbsoluteDate(historyEnd ?? 'now');
     }

--- a/src/configs/EntityConfig.js
+++ b/src/configs/EntityConfig.js
@@ -64,17 +64,17 @@ export default class EntityConfig {
     const historyEnd = config.history_end ?? defaults.historyEnd;
 
     // If start is an entity, setup entity config
-    if (this.isHistoryEntityConfig(historyStart)) {
+    if (HaMapUtilities.isHistoryEntityConfig(historyStart)) {
       this.historyStartEntity = historyStart['entity'] ?? historyStart;
-      this.historyStartEntitySuffix = historyStart['suffix'] ?? 'hours ago';
+      this.historyStartEntitySuffix = historyStart['suffix'] ??  (!isNaN(this.historyStartEntity) ? 'hours ago' : '');
     } else {
         this.historyStart = historyStart ? HaMapUtilities.convertToAbsoluteDate(historyStart) : null;
     }
 
     // If end is an entity, setup entity config
-    if (this.isHistoryEntityConfig(historyEnd)) {
+    if (HaMapUtilities.isHistoryEntityConfig(historyEnd)) {
       this.historyEndEntity = historyEnd['entity'] ?? historyEnd;
-      this.historyEndEntitySuffix = historyEnd['suffix'] ?? 'hours ago';
+      this.historyEndEntitySuffix = historyEnd['suffix'] ?? (!isNaN(this.historyEndEntity) ? 'hours ago' : '');
     } else {
       this.historyEnd = HaMapUtilities.convertToAbsoluteDate(historyEnd ?? 'now');
     }

--- a/src/configs/LayerConfig.js
+++ b/src/configs/LayerConfig.js
@@ -14,6 +14,7 @@ export default class LayerConfig {
 
     this.historyProperty;
     this.historySource;
+    this.historySourceSuffix;
     this.historyForceMidnight;
 
     // history: propName
@@ -29,6 +30,7 @@ export default class LayerConfig {
         this.historyProperty = historyConfig.property;
         this.historySource = historyConfig.source ?? this.historySource;
         this.historyForceMidnight = historyConfig.force_midnight ?? false;
+        this.historySourceSuffix = historyConfig.suffix;
       } else {
         // Singular
         this.historyProperty = historyConfig;

--- a/src/configs/LayerConfig.js
+++ b/src/configs/LayerConfig.js
@@ -4,9 +4,30 @@ export default class LayerConfig {
   /** @type {Object} */
   options;
 
-  constructor(url, options, attribution = null) {
+  constructor(url, options, historyConfig, attribution = null) {
     this.url = url;
     this.options = {...{attribution: attribution}, ...options};
-  }
 
+    this.historyProperty;
+    this.historySource;
+
+    // history: propName
+    // history:
+    //   property: dateTime - value to set
+    //   source: entity.myEntity - source for data. Default to auto (inherit from parent)
+    if (historyConfig) {
+      // Default source
+      this.historySource = 'auto';
+      // Array type
+      if (historyConfig.property) {
+        this.historyProperty = historyConfig.property;
+        this.historySource = historyConfig.source ?? this.historySource;
+      } else {
+        // Singular
+        this.historyProperty = historyConfig;
+      }
+    }
+
+    console.log(this);
+  }
 }

--- a/src/configs/LayerConfig.js
+++ b/src/configs/LayerConfig.js
@@ -4,6 +4,10 @@ export default class LayerConfig {
   /** @type {Object} */
   options;
 
+  historyProperty;
+  historySource;
+  historyForceMidnight;
+
   constructor(url, options, historyConfig, attribution = null) {
     this.url = url;
     this.options = {...{attribution: attribution}, ...options};
@@ -16,6 +20,7 @@ export default class LayerConfig {
     // history:
     //   property: dateTime - value to set
     //   source: entity.myEntity - source for data. Default to auto (inherit from parent)
+    //   force_midnight
     if (historyConfig) {
       // Default source
       this.historySource = 'auto';

--- a/src/configs/LayerConfig.js
+++ b/src/configs/LayerConfig.js
@@ -10,6 +10,7 @@ export default class LayerConfig {
 
     this.historyProperty;
     this.historySource;
+    this.historyForceMidnight;
 
     // history: propName
     // history:
@@ -22,12 +23,11 @@ export default class LayerConfig {
       if (historyConfig.property) {
         this.historyProperty = historyConfig.property;
         this.historySource = historyConfig.source ?? this.historySource;
+        this.historyForceMidnight = historyConfig.force_midnight ?? false;
       } else {
         // Singular
         this.historyProperty = historyConfig;
       }
     }
-
-    console.log(this);
   }
 }

--- a/src/configs/LayerConfig.js
+++ b/src/configs/LayerConfig.js
@@ -7,21 +7,18 @@ export default class LayerConfig {
   historyProperty;
   historySource;
   historyForceMidnight;
+  historySourceSuffix;
 
   constructor(url, options, historyConfig, attribution = null) {
     this.url = url;
     this.options = {...{attribution: attribution}, ...options};
 
-    this.historyProperty;
-    this.historySource;
-    this.historySourceSuffix;
-    this.historyForceMidnight;
-
     // history: propName
     // history:
     //   property: dateTime - value to set
     //   source: entity.myEntity - source for data. Default to auto (inherit from parent)
-    //   force_midnight
+    //   suffix:
+    //   force_midnight:
     if (historyConfig) {
       // Default source
       this.historySource = 'auto';

--- a/src/configs/MapConfig.js
+++ b/src/configs/MapConfig.js
@@ -70,11 +70,16 @@ export default class MapConfig {
       });
     });
 
-    this.wms = (this._setConfigWithDefault(Array.isArray(inputConfig.wms) ? inputConfig.wms : [], [])).map((wms) => {
+
+    // Allow as none array
+    let wms = this._setConfigWithDefault(inputConfig.wms, []);
+    this.wms = (this._setConfigWithDefault(Array.isArray(wms) ? wms : [wms], [])).map((wms) => {
       return new WmsLayerConfig(wms.url, wms.options, wms.history);
     });
 
-    this.tileLayers = (this._setConfigWithDefault(Array.isArray(inputConfig.tile_layers) ? inputConfig.tile_layers : [], [])).map((tile) => {
+    // Allow as none array
+    let tile_layers = this._setConfigWithDefault(inputConfig.tile_layers, []);
+    this.tileLayers = (this._setConfigWithDefault(Array.isArray(tile_layers) ? tile_layers : [tile_layers], [])).map((tile) => {
       return new TileLayerConfig(tile.url, tile.options, tile.history);
     });
 

--- a/src/configs/MapConfig.js
+++ b/src/configs/MapConfig.js
@@ -71,16 +71,17 @@ export default class MapConfig {
     });
 
     this.wms = (this._setConfigWithDefault(Array.isArray(inputConfig.wms) ? inputConfig.wms : [], [])).map((wms) => {
-      return new WmsLayerConfig(wms.url, wms.options);
+      return new WmsLayerConfig(wms.url, wms.options, wms.history);
     });
 
     this.tileLayers = (this._setConfigWithDefault(Array.isArray(inputConfig.tile_layers) ? inputConfig.tile_layers : [], [])).map((tile) => {
-      return new TileLayerConfig(tile.url, tile.options);
+      return new TileLayerConfig(tile.url, tile.options, tile.history);
     });
 
     this.tileLayer = new TileLayerConfig(
       this._setConfigWithDefault(inputConfig.tile_layer_url, "https://tile.openstreetmap.org/{z}/{x}/{y}.png"),
       this._setConfigWithDefault(inputConfig.tile_layer_options, {}),
+      null, // Default layer doesn't pass history by default.
       this._setConfigWithDefault(inputConfig.tile_layer_attribution, '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>')
     );
     if(!(Number.isFinite(this.x) && Number.isFinite(this.y)) && this.focusEntity == null && this.entities.length == 0) {

--- a/src/configs/MapConfig.js
+++ b/src/configs/MapConfig.js
@@ -68,12 +68,13 @@ export default class MapConfig {
           // Is the date range manager enabled
           dateRangeManagerEnabled: (!!this.historyDateSelection)
       });
-
     });
-    this.wms = (this._setConfigWithDefault(inputConfig.wms, [])).map((wms) => {
+
+    this.wms = (this._setConfigWithDefault(Array.isArray(inputConfig.wms) ? inputConfig.wms : [], [])).map((wms) => {
       return new WmsLayerConfig(wms.url, wms.options);
     });
-    this.tileLayers = (this._setConfigWithDefault(inputConfig.tile_layers, [])).map((tile) => {
+
+    this.tileLayers = (this._setConfigWithDefault(Array.isArray(inputConfig.tile_layers) ? inputConfig.tile_layers : [], [])).map((tile) => {
       return new TileLayerConfig(tile.url, tile.options);
     });
 

--- a/src/util/HaMapUtilities.js
+++ b/src/util/HaMapUtilities.js
@@ -68,4 +68,14 @@ export default class HaMapUtilities {
         (typeof value == 'string' && value.includes('.'))
       );
   }
+
+  static getEntityHistoryDate(state, suffix)
+  {
+      // If state isn't set, defualt to hours ago is value is numeric.
+      // If its not numeric, default to no suffix as likely is already be a date.
+      suffix = suffix ?? (!isNaN(state) ? 'hours ago' : '');
+      const value = state + (suffix ? ' ' + suffix : '');
+      console.log(value);
+      return HaMapUtilities.convertToAbsoluteDate(value);
+  }
 }

--- a/src/util/HaMapUtilities.js
+++ b/src/util/HaMapUtilities.js
@@ -59,4 +59,13 @@ export default class HaMapUtilities {
   static removeWarningOnMap(map, message){
     L.control.attribution({prefix:'⚠️'}).removeAttribution(message).addTo(map);
   }
+
+  // entity path or object with an entity:
+  static isHistoryEntityConfig(value) {
+    return (
+        value &&
+        (typeof value == 'object' && value['entity']) ||
+        (typeof value == 'string' && value.includes('.'))
+      );
+  }
 }

--- a/src/util/HaMapUtilities.js
+++ b/src/util/HaMapUtilities.js
@@ -75,7 +75,6 @@ export default class HaMapUtilities {
       // If its not numeric, default to no suffix as likely is already be a date.
       suffix = suffix ?? (!isNaN(state) ? 'hours ago' : '');
       const value = state + (suffix ? ' ' + suffix : '');
-      console.log(value);
       return HaMapUtilities.convertToAbsoluteDate(value);
   }
 }


### PR DESCRIPTION
Allows WMS/Tile layers to have their time/date driven by the date picker or an external entity as with entity history.

* Setting `history` on WMS/Tile layer will link it to history mechanism set at map level. This supports specific date/times, entity driven date times and date picker date times. Will use the start point of any time ranges.
* Works for both WMS and Tile layers
* None date linked WMS and Tile layers still work as before.
* WMS/Layer history supports sub properties `source` to set custom entity or date to use for layer. `suffix` can also be set on source as with other history properties. 
* Additional flag on layers to `force_midnight` as some WMS/Maps only return results if date is at midnight e.g. https://geo.irceline.be/rioifdm/wms

Simple example with WMS driven by date_section date range picker
```
type: custom:map-card
history_date_selection: true
entities:
  - zone.home
wms:
  - url: https://geo.irceline.be/rioifdm/wms
    history: time
    options:
      layers: pm25_hmean
      transparent: true
      format: image/png
      opacity: 0.7
      tiled: true
      attribution: <a href="https://www.irceline.be/">IRCELINE</a>
```

More advanced example with tile_layer
```
type: custom:map-card
history_date_selection: false
entities:
  - zone.home
tile_layers:
  url: >-
    https://wmts.marine.copernicus.eu/teroWmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=&LAYER={layer}&STYLE=&FORMAT=image/png&TILEMATRIXSET={tileMatrixSet}&TILEMATRIX={z}&time={time}&TILEROW={y}&TILECOL={x}
  history:
    property: time
    source: input_number.test_number_value
    suffix: months ago
  options:
    layer: >-
      GLOBAL_MULTIYEAR_WAV_001_032/cmems_mod_glo_wav_my_0.2deg_PT3H-i_202311/VHM0
    tileMatrixSet: EPSG:4326
    noWrap: true

```

Work todo
- [x] Refactor a little. Tilelayers can likely reuse same code for extra logic. Need to fine example tile layer to test with.
- [x] Check `source` entity works as expected.
- [x] Add source_suffix
- [x] Update readme with instructions on how to use it.
- [x] Wrap suffix logic into a util as is now repeated in 3/4 places

Fixes https://github.com/nathan-gs/ha-map-card/issues/44