### PR TITLE
Use configured device_trackers for person type entities. 

### DIFF
--- a/src/services/HaHistoryService.js
+++ b/src/services/HaHistoryService.js
@@ -27,7 +27,7 @@ export default class HaHistoryService {
     let params = {  
       type: 'history/stream',  
       entity_ids: trackerEntityIds,
-      significant_changes_only: true,
+      significant_changes_only: false,
       start_time: start.toISOString()
     };
 
@@ -40,6 +40,7 @@ export default class HaHistoryService {
 
       this.connection[entityId] = this.hass.connection.subscribeMessage(
         (message) => {
+          console.log(message.states);
           // entities providing results
           Object.values(message.states).map((entity) => {
             // Each entity can return own results

--- a/src/util/HaMapUtilities.js
+++ b/src/util/HaMapUtilities.js
@@ -59,4 +59,28 @@ export default class HaMapUtilities {
   static removeWarningOnMap(map, message){
     L.control.attribution({prefix:'⚠️'}).removeAttribution(message).addTo(map);
   }
+
+  // Get Lat/Lng of entity. Some entities such as "person" define device_trackers allowing
+  // multiple lat/lng sources to be used. This method will call down through these looking for a
+  // lat/lng value if none is defined on the parent entity.
+  static getEntityLatLng(entityId, states) {
+    let entity = states[entityId];
+
+    // Do we have Lng/Lat directly?
+    if (entity.attributes.latitude && entity.attributes.longitude) {
+        return [entity.attributes.latitude, entity.attributes.longitude];
+    }
+
+    // If any, see if we can get a lng/lat from one instead
+    let subTrackerIds = states[entityId]?.attributes?.device_trackers ?? []
+    for(let t=0; t<subTrackerIds.length; t++) {
+      entity = states[subTrackerIds[t]];
+      if (entity.attributes.latitude && entity.attributes.longitude) {
+          return [entity.attributes.latitude, entity.attributes.longitude];
+      }
+    }
+
+    // :(
+    return null;
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/nathan-gs/ha-map-card/issues/27

Person entities allow you to define a set of device_trackers, each of which acts as a source of location data for the person. This PR adds the ability for the map card to detect configured `device_trackers` and pull both lat/lng and history data for them.

Key changes
* History now listens to all device trackers configured against an entity such as a person.
* Lat/Lng moved to util function. Will return lat/lng data from device_trackers if none found on entity directly.