### PR TITLE
Add support for dark mode

### DIFF
--- a/src/components/MapCardEntityMarker.js
+++ b/src/components/MapCardEntityMarker.js
@@ -9,14 +9,15 @@ export default class MapCardEntityMarker extends LitElement {
       'picture': {type: String, attribute: 'picture'},
       'icon': {type: String, attribute: 'icon'},
       'color': {type: String, attribute: 'color'},
-      'size': {type: Number}
+      'size': {type: Number},
+      'darkMode': {type: Boolean, attribute: 'dark-mode'},
     };
   }
 
   render() {
    return html`
       <div
-        class="marker ${this.picture ? "picture" : ""}"
+        class="marker ${this.picture ? "picture" : ""}  ${this.darkMode ? "dark" : ""}"
         style="border-color: ${this.color}; height: ${this.size}px; width: ${this.size}px;"
         @click=${this._badgeTap}
         title="${this.tooltip}"
@@ -75,6 +76,10 @@ export default class MapCardEntityMarker extends LitElement {
         background-size: cover;
         height: 100%;
         width: 100%;
+      }
+      .marker.dark {
+        color: var(--card-background-color);
+        background-color: var(--primary-text-color);
       }
     `;
   }

--- a/src/configs/MapConfig.js
+++ b/src/configs/MapConfig.js
@@ -31,6 +31,8 @@ export default class MapConfig {
   historyEnd;
   /** @type {boolean} */
   historyDateSelection;
+  /** @type {string} */
+  themeMode;
 
   /** @type {boolean} */
   debug = false;
@@ -42,6 +44,9 @@ export default class MapConfig {
     this.y = inputConfig.y;
     this.zoom = this._setConfigWithDefault(inputConfig.zoom, 12);
     this.cardSize = this._setConfigWithDefault(inputConfig.card_size, 5);
+
+    // Get theme mode.
+    this.themeMode = ['dark', 'light', 'auto'].includes(inputConfig.theme_mode) ? inputConfig.theme_mode : 'auto';
 
     // Enable debug messaging. 
     // Card is quite chatty with this enabled.

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -34,14 +34,14 @@ export default class Entity {
     return this.config.display;
   }
 
-  constructor(config, latitude, longitude, icon, title, state, picture) {
+  constructor(config, latitude, longitude, icon, title, state, picture, darkMode) {
     this.config = config;
     if(this.display == "state") {
       title = state;
       this._currentState = state;
     }
     this.title = title;
-    this.marker = this._createMapMarker(latitude, longitude, icon, title, picture);
+    this.marker = this._createMapMarker(latitude, longitude, icon, title, picture, darkMode);
   }
 
   _markerCss(size) {
@@ -107,7 +107,7 @@ export default class Entity {
     return this.histories.map((entHist) => entHist.render()).flat();  
   }
 
-  _createMapMarker(latitude, longitude, icon, title, picture) {
+  _createMapMarker(latitude, longitude, icon, title, picture, darkMode) {
     Logger.debug("[MarkerEntity] Creating marker for " + this.id + " with display mode " + this.display);
     if(this.display == "icon") {
       picture = null;
@@ -131,10 +131,11 @@ export default class Entity {
             color="${this.config.color}"
             style="${this.config.css}"
             size="${this.config.size}"
+            dark-mode="{$darkMode}"
           ></map-card-entity-marker>
         `,
         iconSize: [this.config.size, this.config.size],
-        className: "",
+        className: '',
       }),
       title: this.id,
     });

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -131,7 +131,7 @@ export default class Entity {
             color="${this.config.color}"
             style="${this.config.css}"
             size="${this.config.size}"
-            dark-mode="{$darkMode}"
+            dark-mode="${darkMode}"
           ></map-card-entity-marker>
         `,
         iconSize: [this.config.size, this.config.size],


### PR DESCRIPTION
fixes https://github.com/nathan-gs/ha-map-card/issues/25

This changes aims to simulate the `theme_mode` property of the HA core map.
*  `theme_mode` can be set as light, dark or auto. Default to auto.
* When theme mode is auto use `this.hass.themes.darkMode` to determine theme to use.
* Add styles for map/marker darkmode.
