### PR TITLE
Dark mode tweaks

### DIFF
--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -408,6 +408,13 @@ export default class MapCard extends LitElement {
         --map-filter: invert(0.9) hue-rotate(170deg) brightness(1.5)
           contrast(1.2) saturate(0.3);
       }
+      #map.dark .leaflet-control-attribution {
+        background: #000000cc;
+        color: #ffffff;
+      }
+      #map.dark .leaflet-control-attribution a {
+        color: #ffffff;
+      }
       #map.light {
         background: #ffffff;
         color: #000000;

--- a/src/components/MapCardEntityMarker.js
+++ b/src/components/MapCardEntityMarker.js
@@ -78,8 +78,8 @@ export default class MapCardEntityMarker extends LitElement {
         width: 100%;
       }
       .marker.dark {
-        color: var(--card-background-color);
-        background-color: var(--primary-text-color);
+        color: #ffffff;
+        background: #1c1c1c;
       }
     `;
   }


### PR DESCRIPTION
* Adds dark mode styles for the attribution.
* Fixes bug where icons show wrong colours when in "real" dark mode rather than `theme_mode: dark`. Looks like need to set colours directly as wider default darkmode theme inverts all the vars. This solution appears to be same one used in core map https://github.com/home-assistant/frontend/blob/a6ef46565f8e98ea47e853ceb7d2dc5baa00ed36/src/components/map/ha-map.ts#L557

![image](https://github.com/nathan-gs/ha-map-card/assets/887397/cd9a66ce-5221-4f85-93e8-85e2b7729f31)
