### PR TITLE
Custom actions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Either the name of the `entity` or:
 | `fixed_y`             |                                       | Display a fixed marker, this will ignore the latitude/longitude attributes                    |
 | `fallback_x`          |                                       | If the latitude/longitude is missing, use these fixed attributes                              |
 | `fallback_y`          |                                       | If the latitude/longitude is missing, use these fixed attributes                              |
-
+| `tap_action`          | {"action": "more-info"}               | Allow custom action to be triggered when this entity is clicked. Actions include `more-info`, `call-service`, `navigate`, `url`, `assist`, `none`. Some actions require additional paramaters. `navigate` requires a `navigation_path`. `url` requires a `url_path`. `call-service` requires `service` and an optional `data`|
 
 #### History options.
 

--- a/src/components/MapCardEntityMarker.js
+++ b/src/components/MapCardEntityMarker.js
@@ -10,6 +10,7 @@ export default class MapCardEntityMarker extends LitElement {
       'icon': {type: String, attribute: 'icon'},
       'color': {type: String, attribute: 'color'},
       'size': {type: Number},
+      'tapAction': {type: Object, attribute: 'tap-action'},
       'extraCssClasses': {type: String, attribute: 'extra-css-classes'},
     };
   }
@@ -33,9 +34,8 @@ export default class MapCardEntityMarker extends LitElement {
       // https://developers.home-assistant.io/blog/2023/07/07/action-event-custom-cards/
       const actions = {
         entity: this.entityId,
-        tap_action: {
-          action: "more-info",
-        }
+        // Passed from entity
+        tap_action: this.tapAction
       };
 
       const event = new Event('hass-action', {bubbles: true, composed: true});

--- a/src/configs/EntityConfig.js
+++ b/src/configs/EntityConfig.js
@@ -42,6 +42,8 @@ export default class EntityConfig {
   picture;
   /** @type {string} */
   color;
+  /** @type {object} */
+  tapAction;
 
   // Is valye of this config item a HistoryEntity vs a date
   isHistoryEntityConfig(value) {
@@ -91,6 +93,52 @@ export default class EntityConfig {
 
     // If no start/end date values are given, fallback to using date range manager
     this.usingDateRangeManager = (!historyStart && !historyEnd) && defaults.dateRangeManagerEnabled;
+
+    // Tap action defaults to standard more-info.
+    this.tapAction = (typeof config.tap_action == 'object') ? this.parseAction(config.tap_action) : {action: 'more-info'};
+  }
+
+  // Get tap action_data
+  parseAction(tap_action)
+  {
+    // No additional props
+    if (['more-info', 'none'].includes(tap_action.action)) {
+      return {
+        action: tap_action.action,
+      };
+    }
+
+    if (tap_action.action == 'navigate') {
+      // Validate
+      if(!tap_action.navigation_path) throw new Error("'navigation_path' is required when using action 'navigate'");
+
+      return {
+        action: tap_action.action,
+        navigation_path: tap_action.navigation_path
+      };
+    }
+    if (tap_action.action == 'url') {
+      // Validate
+      if(!tap_action.url_path) throw new Error("'url_path' is required when using action 'url'");
+
+      return {
+        action: tap_action.action,
+        url_path: tap_action.url_path 
+      };
+    }
+
+    if (tap_action.action == 'call-service') {
+      // Validate
+      if (!tap_action.url_path) throw new Error("'service' is required when using action 'call-service'");
+      return {
+        action:   tap_action.action,
+        service:  tap_action.service,
+        // I belive this is truely optional.
+        data:     tap_action.data   
+      };
+    }
+
+    throw Error(`Unknown tap action "${tap_action.action}". Ensure action on tap_action is set.`);
   }
 
   get hasHistory() {

--- a/src/configs/EntityConfig.js
+++ b/src/configs/EntityConfig.js
@@ -129,7 +129,7 @@ export default class EntityConfig {
 
     if (tap_action.action == 'call-service') {
       // Validate
-      if (!tap_action.url_path) throw new Error("'service' is required when using action 'call-service'");
+      if (!tap_action.service) throw new Error("'service' is required when using action 'call-service'");
       return {
         action:   tap_action.action,
         service:  tap_action.service,

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -138,6 +138,7 @@ export default class Entity {
             style="${this.config.css}"
             size="${this.config.size}"
             extra-css-classes="${extraCssClasses}"
+            tap-action='${JSON.stringify(this.config.tapAction)}'
           ></map-card-entity-marker>
         `,
         iconSize: [this.config.size, this.config.size],


### PR DESCRIPTION
Allows tap actions be defined for entities.

Defined along lines of
```
  - entity: person.someone
    tap_action:
      action: navigate
      navigation_path: /a/location

```

**Key changes**
* Will default to more-info when not set
* Config will validate requires params for each action, e.g. navigate requires the `navigation_path`.
* Passes validated config down to Marker Component to act on.
* Updated readme with details on new feature.

The change should support all the possible custom card actions defined in https://developers.home-assistant.io/blog/2023/07/07/action-event-custom-cards/ with the exception of `toggle` as I don't think it is relevant to person/trackers.

fixes:  https://github.com/nathan-gs/ha-map-card/issues/19

