### PR TITLE
Allow setting a custom icon on an entity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Either the name of the `entity` or:
 | `entity`               |                                       | The entity id                                                                                 |
 | `display`              | `marker`                              | `icon`, `state` or `marker`. `marker` will display the picture if available                   |
 | `picture`              |                                       | Set a custom picture to use on the marker.                                                    |
+| `icon`                 |                                       | Set a custom icon to use if display is set to `icon`. e.g. mdi:cake                           |
 | `size`                 | 48                                    | Size of the icon                                                                              |
 | `color`                | Random Color                          | Can defined as `red`, `rgb(255,0,0)`, `rgba(255,0,0,0.1)`, `#ff0000`, `var(--red-color)`      |
 | `css`                  | `text-align: center; font-size: 60%;` | CSS for the marker (only for `state` and `marker`)                                            |

--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -227,7 +227,7 @@ export default class MapCard extends LitElement {
       const stateObj = hass.states[configEntity.id];
       const {
         //passive,
-        entity_icon,
+        icon: entity_icon,
         //radius,
         entity_picture,
         //gps_accuracy: gpsAccuracy,

--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -246,7 +246,7 @@ export default class MapCard extends LitElement {
       // Skip if neither found and return null
       picture = picture ? hass.hassUrl(picture) : null;
 
-      // Overvide icon?
+      // Override icon?
       let icon = configEntity.icon ?? entity_icon;
 
       // Attempt to setup entity. Skip on fail, so one bad entity does not affect others.

--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -227,12 +227,13 @@ export default class MapCard extends LitElement {
       const stateObj = hass.states[configEntity.id];
       const {
         //passive,
-        icon,
+        entity_icon,
         //radius,
         entity_picture,
         //gps_accuracy: gpsAccuracy,
         friendly_name
       } = stateObj.attributes;
+
       const state = hass.formatEntityState(stateObj);
 
       // Get lat lng
@@ -244,6 +245,9 @@ export default class MapCard extends LitElement {
       let picture = configEntity.picture ?? entity_picture;
       // Skip if neither found and return null
       picture = picture ? hass.hassUrl(picture) : null;
+
+      // Overvide icon?
+      let icon = configEntity.icon ?? entity_icon;
 
       // Attempt to setup entity. Skip on fail, so one bad entity does not affect others.
       try {

--- a/src/components/MapCardEntityMarker.js
+++ b/src/components/MapCardEntityMarker.js
@@ -49,7 +49,7 @@ export default class MapCardEntityMarker extends LitElement {
       return html`<div class="entity-picture" style="background-image: url(${this.picture})"></div>`
     }
     if(this.icon) {
-      return html`<ha-icon icon="${this.icon}" style="--icon-primary-color: ${this.color}; --mdc-icon-size: ${this.size - 5}px;">icon</ha-icon>`
+      return html`<ha-icon icon="${this.icon}" style="--icon-primary-color: ${this.color}; --mdc-icon-size: ${this.size - 10}px;">icon</ha-icon>`
     }
     return this.title;
   }

--- a/src/configs/EntityConfig.js
+++ b/src/configs/EntityConfig.js
@@ -40,6 +40,8 @@ export default class EntityConfig {
   
   /** @type {string} */
   picture;
+  /** @type {icon} */
+  picture;
   /** @type {string} */
   color;
   /** @type {number} */
@@ -90,6 +92,7 @@ export default class EntityConfig {
     this.fallbackY = config.fallback_y;
     this.css = config.css ?? "text-align: center; font-size: 60%;";
     this.picture = config.picture ?? null;
+    this.icon = config.icon ?? null;
 
     // If no start/end date values are given, fallback to using date range manager
     this.usingDateRangeManager = (!historyStart && !historyEnd) && defaults.dateRangeManagerEnabled;

--- a/src/configs/EntityConfig.js
+++ b/src/configs/EntityConfig.js
@@ -40,8 +40,8 @@ export default class EntityConfig {
   
   /** @type {string} */
   picture;
-  /** @type {icon} */
-  picture;
+  /** @type {string} */
+  icon;
   /** @type {string} */
   color;
   /** @type {number} */


### PR DESCRIPTION
Add support for providing a specific icon to use when display is set icon on an entity.

Fixes: https://github.com/nathan-gs/ha-map-card/issues/84

Been a while since I've looked at this repo, so hopefully I've not forgotten anything. Adds the ability to provide an icon attribute on entities (similar to picture) which will be sued if the entities display is set as icon. 

I've also reduce the icon size a tiny bit as a lot of icons looked a little odd in place at the original size.
![image](https://github.com/user-attachments/assets/9fe20094-bd0d-46c2-921a-c3e56beaada4)
