### PR TITLE
Map Options: allow to set Leaflet options directly on the map

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ y: 3.652
 | `tile_layer_options` | {}                                                                                                                               | The `options` for the default [TileLayer](https://leafletjs.com/reference.html#tilelayer) |
 | `history_date_selection` | false                                                                                                                        | Will link with a `energy-date-selection` on the page to provide an interactive  date range picker. |
 | `theme_mode`          | auto                                  | `auto`, `light` or`dark`                                                                      |
+| `map_options`          | {}                                                                                                                           | The `options` for the default [Leaflet Map](https://leafletjs.com/reference.html#map) |
 | `debug` | false                                                                                                                        | Enable debug messages in console.
 
 

--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -296,7 +296,7 @@ export default class MapCard extends LitElement {
     L.Icon.Default.imagePath = "/static/images/leaflet/images/";
 
     const mapEl = this.shadowRoot.querySelector('#map');
-    let map = L.map(mapEl);
+    let map = L.map(mapEl, this._config.mapOptions);
 
     // Add dark class if darkmode
     this._isDarkMode() ? mapEl.classList.add('dark') : mapEl.classList.add('light');

--- a/src/configs/MapConfig.js
+++ b/src/configs/MapConfig.js
@@ -33,6 +33,8 @@ export default class MapConfig {
   historyDateSelection;
   /** @type {string} */
   themeMode;
+  /** @type {object} */
+  mapOptions;
 
   /** @type {boolean} */
   debug = false;
@@ -44,6 +46,7 @@ export default class MapConfig {
     this.y = inputConfig.y;
     this.zoom = this._setConfigWithDefault(inputConfig.zoom, 12);
     this.cardSize = this._setConfigWithDefault(inputConfig.card_size, 5);
+    this.mapOptions = this._setConfigWithDefault(inputConfig.map_options, {});
 
     // Get theme mode.
     this.themeMode = ['dark', 'light', 'auto'].includes(inputConfig.theme_mode) ? inputConfig.theme_mode : 'auto';

--- a/src/configs/MapConfig.test.js
+++ b/src/configs/MapConfig.test.js
@@ -1,0 +1,21 @@
+import MapConfig from "./MapConfig.js";
+import { describe, expect, it } from "@jest/globals";
+
+describe("MapConfig", () => {
+  describe("constructor", () => {
+    it("mapOptions", () => {
+      const mapConfig = new MapConfig({
+        x: 0.1,
+        y: 0.1,
+        map_options: { dragging: true },
+      });
+
+      expect(mapConfig.mapOptions.dragging).toBe(true);
+    });
+
+    it("complains when neither a [X, Y], an entity or a focus entity is given", () => {      
+      expect(() =>  new MapConfig({})).toThrowError("We need a map latitude & longitude; set at least [x, y], a focus_entity or have at least 1 entities defined.");
+    });
+    
+  });
+});

--- a/src/services/HaUrlResolveService.test.js
+++ b/src/services/HaUrlResolveService.test.js
@@ -44,9 +44,15 @@ describe("HaUrlResolveService", () => {
           "sensor.mySensor": { state: "on" },
         },
       };
+
+      jest.spyOn(console, 'warn').mockImplementation();
+
       const haUrlResolveService = new HaUrlResolveService(hass);
       const url = "http://localhost:8123/{{ states('sensor.mySensor') }}/test/{{ states('sensor.myOtherSensor') }}/bla";
       expect(haUrlResolveService.resolveUrl(url)).toBe("http://localhost:8123/on/test//bla");
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('[HaUrlResolveService]: sensor.myOtherSensor not found'),
+      )
     });
 
     it("should resolve URLs coming from linkedentityservice", () => {


### PR DESCRIPTION
Allow to set [Leaflet Map](https://leafletjs.com/reference.html#map) options directly on the Map, this fixes:
- #100