### PR TITLE
Don't wait for next hass update tick to render

### DIFF
--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -52,6 +52,9 @@ export default class MapCard extends LitElement {
     this.map = this._setupMap();
     // redraw the map every time it resizes
     this.resizeObserver = this._setupResizeObserver();
+
+    // Try to render immediately after map is ready
+    this.render()
   };
 
   setUpHistory() {


### PR DESCRIPTION
After looking into the issue in #78 a bit, I found that the trigger for first map render is **always** a new `hass` state objet event. This is *typically* every ~10 seconds. However, since the events are completely async, something could cause an emission sooner (or later).

I don't see any reason why we need to actually wait to render, provided the map object itself is ready. Perhaps there is another way to avoid the wait cycle, but I'm not very knowledgeable when it comes to Lit component lifecycle. In any event, once the map is ready, we could try to render instead of sitting until some other external event prompts it.

I pushed up a version in my fork and have been running it in my own instance with a few different **basic** configs without issue. That being said, there is a lot that this wonderful integration offers, so please advise if there are other considerations I've missed!

