### PR TITLE
Update README.md: remark about displaying an icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,7 @@ Either the name of the `entity` or:
 | name                   | Default                               | note                                                                                          |
 |------------------------|---------------------------------------|-----------------------------------------------------------------------------------------------|
 | `entity`               |                                       | The entity id                                                                                 |
-| `display`              | `marker`                              | `icon`, `state` or `marker`.
-`marker` will display the picture if available.
-`icon` will display the icon if available, otherwise a label composed of first letters of the entity's name. |
+| `display`              | `marker`                              | `icon`, `state` or `marker`. <br/>`marker` will display the picture if available. <br/>`icon` will display the icon if available, otherwise a label composed of first letters of the entity's name. |
 | `picture`              |                                       | Set a custom picture to use on the marker.                                                    |
 | `icon`                 |                                       | Set a custom icon to use if display is set to `icon`. e.g. mdi:cake                           |
 | `size`                 | 48                                    | Size of the icon                                                                              |

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Either the name of the `entity` or:
 | name                   | Default                               | note                                                                                          |
 |------------------------|---------------------------------------|-----------------------------------------------------------------------------------------------|
 | `entity`               |                                       | The entity id                                                                                 |
-| `display`              | `marker`                              | `icon`, `state` or `marker`.                                                                  |
-|                        |                                       | `marker` will display the picture if available.                                               |
-|                        |                                       | `icon` will display the icon if available, otherwise a label composed of first letters of the entity's name. |
+| `display`              | `marker`                              | `icon`, `state` or `marker`.
+`marker` will display the picture if available.
+`icon` will display the icon if available, otherwise a label composed of first letters of the entity's name. |
 | `picture`              |                                       | Set a custom picture to use on the marker.                                                    |
 | `icon`                 |                                       | Set a custom icon to use if display is set to `icon`. e.g. mdi:cake                           |
 | `size`                 | 48                                    | Size of the icon                                                                              |

--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ Either the name of the `entity` or:
 | name                   | Default                               | note                                                                                          |
 |------------------------|---------------------------------------|-----------------------------------------------------------------------------------------------|
 | `entity`               |                                       | The entity id                                                                                 |
-| `display`              | `marker`                              | `icon`, `state` or `marker`. `marker` will display the picture if available                   |
+| `display`              | `marker`                              | `icon`, `state` or `marker`.                                                                  |
+|                        |                                       | `marker` will display the picture if available.                                               |
+|                        |                                       | `icon` will display the icon if available, otherwise the 1st letter of the entity's name.     |
 | `picture`              |                                       | Set a custom picture to use on the marker.                                                    |
 | `icon`                 |                                       | Set a custom icon to use if display is set to `icon`. e.g. mdi:cake                           |
 | `size`                 | 48                                    | Size of the icon                                                                              |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Either the name of the `entity` or:
 | `entity`               |                                       | The entity id                                                                                 |
 | `display`              | `marker`                              | `icon`, `state` or `marker`.                                                                  |
 |                        |                                       | `marker` will display the picture if available.                                               |
-|                        |                                       | `icon` will display the icon if available, otherwise the 1st letter of the entity's name.     |
+|                        |                                       | `icon` will display the icon if available, otherwise a label composed of first letters of the entity's name. |
 | `picture`              |                                       | Set a custom picture to use on the marker.                                                    |
 | `icon`                 |                                       | Set a custom icon to use if display is set to `icon`. e.g. mdi:cake                           |
 | `size`                 | 48                                    | Size of the icon                                                                              |


### PR DESCRIPTION
Noticed this thing:
```
type: custom:map-card
title: color
entities:
  - entity: device_tracker.virtual_tracker_1
    display: icon
  - entity: device_tracker.virtual_tracker_2
    display: icon
    icon: mdi:car
card_size: 10
```
![image](https://github.com/user-attachments/assets/e20c74f7-502c-4520-aa92-e9cfb51a01ec)

The entity does not have an `icon` attribute:
![image](https://github.com/user-attachments/assets/4dbd5e98-0536-4bb1-ae21-7bf3429b0934)

Instead of an icon the 1st letter "V" (capital) is displayed.
So, imho we should add a remark about it to Readme.

@nathan-gs
In a stock Map card it could be up to 3 letters:
![image](https://github.com/user-attachments/assets/0219aff2-95c9-4d44-97d2-4c624ba878a3)
Seems to be a default behaviour.
That is why I have not specified a detailed description how this label is composed.