### PR TITLE
Implement fix to stop fade/flicker when dynamically updating the URL of a TileLayer.

### DIFF
--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -11,6 +11,7 @@ import HaUrlResolveService from '../services/HaUrlResolveService.js';
 import TileLayersService from '../services/render/TileLayersRenderService.js';
 import EntitiesRenderService from '../services/render/EntitiesRenderService.js';
 import InitialViewRenderService from '../services/render/InitialViewRenderService.js';
+import TileLayer from '../leaflet/TileLayer.js';
 
 export default class MapCard extends LitElement {
   static get properties() {
@@ -156,7 +157,7 @@ export default class MapCard extends LitElement {
     this._isDarkMode() ? mapEl.classList.add('dark') : mapEl.classList.add('light');
 
     let tileUrl = this.urlResolver.resolveUrl(this._config.tileLayer.url);
-    let layer = L.tileLayer(tileUrl, this._config.tileLayer.options);
+    let layer = new TileLayer(tileUrl, this._config.tileLayer.options);
     map.addLayer(layer);
     this.urlResolver.registerLayer(layer, this._config.tileLayer.url);    
     return map;

--- a/src/leaflet/Redraw.js
+++ b/src/leaflet/Redraw.js
@@ -1,0 +1,52 @@
+import L from 'leaflet';
+import Logger from '../util/Logger';
+
+// adapted from @barryhunter's implementation:
+// https://github.com/Leaflet/Leaflet/issues/6659#issuecomment-491545545
+// https://gist.github.com/barryhunter/e42f0c4756e34d5d07db4a170c7ec680
+/**
+ * 
+ * @param {object} tile 
+ * @param {string} url 
+ */
+function refreshTileUrl(tile, url) {
+  const img = new Image();
+  img.onload = function () {
+    L.Util.requestAnimFrame(function () {
+      tile.el.src = url;
+    });
+  };
+  img.src = url;
+}
+
+/**
+ * @param {object} layerInstance 
+ */
+export function redraw(layerInstance) {
+  Logger.debug(`[TileLayer.Redraw]: Refreshing tiles`);
+  if (!layerInstance._map) {
+    Logger.debug(`[TileLayer.Redraw]: Map not (yet) loaded, skipping refresh`);
+    return;
+  }
+  const wasAnimated = layerInstance._map._fadeAnimated;
+  layerInstance._map._fadeAnimated = false;
+
+  for (var key in layerInstance._tiles) {
+    var tile = layerInstance._tiles[key];
+    if (tile.current && tile.active) {
+      const oldsrc = tile.el.src;
+      const newsrc = layerInstance.getTileUrl(tile.coords);
+      if (oldsrc != newsrc) {
+        refreshTileUrl(tile, newsrc);
+      }
+    }
+  }
+
+  if (wasAnimated) {
+    setTimeout(() => {
+      if (layerInstance._map) {
+        layerInstance._map._fadeAnimated = wasAnimated;
+      }
+    }, 5000);
+  }
+}

--- a/src/leaflet/Redraw.js
+++ b/src/leaflet/Redraw.js
@@ -31,8 +31,8 @@ export function redraw(layerInstance) {
   const wasAnimated = layerInstance._map._fadeAnimated;
   layerInstance._map._fadeAnimated = false;
 
-  for (var key in layerInstance._tiles) {
-    var tile = layerInstance._tiles[key];
+  for (const key in layerInstance._tiles) {
+    const tile = layerInstance._tiles[key];
     if (tile.current && tile.active) {
       const oldsrc = tile.el.src;
       const newsrc = layerInstance.getTileUrl(tile.coords);

--- a/src/leaflet/Redraw.test.js
+++ b/src/leaflet/Redraw.test.js
@@ -1,0 +1,67 @@
+import Logger from '../util/Logger';
+import { redraw } from './Redraw';
+import {describe, expect, it, jest} from "@jest/globals";
+
+jest.mock('../util/Logger.js');
+
+describe('Tile Layer Refresh Functions', () => {
+
+
+  describe('redraw', () => {
+    it('should handle when map is not loaded', () => {
+      const mockLayer = {
+        _map: null,
+        getTileUrl: jest.fn(),
+      };
+
+      redraw(mockLayer);
+
+      expect(Logger.debug).toHaveBeenCalledWith('[TileLayer.Redraw]: Map not (yet) loaded, skipping refresh');
+    });
+
+    it('should refresh tiles when map is loaded', () => {
+      const mockLayer = {
+        _map: {
+          _fadeAnimated: true,
+        },
+        _tiles: {
+          '0': {
+            current: true,
+            active: true,
+            el: { src: 'old-url.jpg' },
+            coords: { x: 0, y: 0, z: 0 },
+          },
+        },
+        getTileUrl: jest.fn(() => 'new-url.jpg'),
+      };
+
+      redraw(mockLayer);
+
+      expect(Logger.debug).toHaveBeenCalledWith('[TileLayer.Redraw]: Refreshing tiles');
+      expect(mockLayer._map._fadeAnimated).toBe(false);
+      expect(mockLayer.getTileUrl).toHaveBeenCalledWith({ x: 0, y: 0, z: 0 });      
+
+    });
+
+    it('should not refresh if tile URL hasn\'t changed', () => {
+      const mockLayer = {
+        _map: {
+          _fadeAnimated: true,
+        },
+        _tiles: {
+          '0': {
+            current: true,
+            active: true,
+            el: { src: 'same-url.jpg' },
+            coords: { x: 0, y: 0, z: 0 },
+          },
+        },
+        getTileUrl: jest.fn(() => 'same-url.jpg'),
+      };
+
+      redraw(mockLayer);
+      expect(mockLayer._tiles['0'].el.src).toBe('same-url.jpg');
+
+    });
+  });
+});

--- a/src/leaflet/TileLayer.js
+++ b/src/leaflet/TileLayer.js
@@ -7,7 +7,7 @@ import Logger from "../util/Logger";
 export default class TileLayer extends L.TileLayer {
   _refreshTileUrl(tile, url) {
     //use a image in background, so that only replace the actual tile, once image is loaded in cache!
-    var img = new Image();
+    const img = new Image();
     img.onload = function () {
       L.Util.requestAnimFrame(function () {
         tile.el.src = url;
@@ -23,14 +23,14 @@ export default class TileLayer extends L.TileLayer {
       return;
     }
     //prevent _tileOnLoad/_tileReady re-triggering a opacity animation
-    var wasAnimated = this._map._fadeAnimated;
+    const wasAnimated = this._map._fadeAnimated;
     this._map._fadeAnimated = false;
 
     for (var key in this._tiles) {
       var tile = this._tiles[key];
       if (tile.current && tile.active) {
-        var oldsrc = tile.el.src;
-        var newsrc = this.getTileUrl(tile.coords);
+        const oldsrc = tile.el.src;
+        const newsrc = this.getTileUrl(tile.coords);
         if (oldsrc != newsrc) {
           this._refreshTileUrl(tile, newsrc);
         }
@@ -38,7 +38,7 @@ export default class TileLayer extends L.TileLayer {
     }
 
     if (wasAnimated) {
-      setTimeout(function () {
+      setTimeout(() => {
         if(this._map) {
           this._map._fadeAnimated = wasAnimated;
         }

--- a/src/leaflet/TileLayer.js
+++ b/src/leaflet/TileLayer.js
@@ -1,9 +1,11 @@
-// adapted from @barryhunter's implementation:
-// https://github.com/Leaflet/Leaflet/issues/6659#issuecomment-491545545
-
 import L from 'leaflet';
 
-class TileLayer extends L.TileLayer {
+// adapted from @barryhunter's implementation:
+// https://github.com/Leaflet/Leaflet/issues/6659#issuecomment-491545545
+// https://gist.github.com/barryhunter/e42f0c4756e34d5d07db4a170c7ec680
+
+export default class TileLayer extends L.TileLayer {
+
   _refreshTileUrl(tile, url) {
     //use a image in background, so that only replace the actual tile, once image is loaded in cache!
     var img = new Image();
@@ -21,7 +23,7 @@ class TileLayer extends L.TileLayer {
     this._map._fadeAnimated = false;
 
     for (var key in this._tiles) {
-      tile = this._tiles[key];
+      var tile = this._tiles[key];
       if (tile.current && tile.active) {
         var oldsrc = tile.el.src;
         var newsrc = this.getTileUrl(tile.coords);
@@ -32,9 +34,6 @@ class TileLayer extends L.TileLayer {
     }
 
     if (wasAnimated)
-      setTimeout(function() { map._fadeAnimated = wasAnimated; }, 5000);
+      setTimeout(function() { this._map._fadeAnimated = wasAnimated; }, 5000);
   }
 }
-
-
-export { TileLayer };

--- a/src/leaflet/TileLayer.js
+++ b/src/leaflet/TileLayer.js
@@ -16,7 +16,7 @@ export default class TileLayer extends L.TileLayer {
     img.src = url;
   }
 
-  refresh() {
+  redraw() {
     Logger.debug(`[TileLayer]: Refreshing tiles`);
     if(!this._map) {
       Logger.debug(`[TileLayer]: Map not (yet) loaded, skipping refresh`)

--- a/src/leaflet/TileLayer.js
+++ b/src/leaflet/TileLayer.js
@@ -5,6 +5,6 @@ import { redraw } from './Redraw';
 export default class TileLayer extends L.TileLayer {
 
   redraw() {
-    redraw(this)
+    redraw(this);
   }
 }

--- a/src/leaflet/TileLayer.js
+++ b/src/leaflet/TileLayer.js
@@ -3,7 +3,7 @@
 
 import L from 'leaflet';
 
-class TileLayer2 extends L.TileLayer {
+class TileLayer extends L.TileLayer {
   _refreshTileUrl(tile, url) {
     //use a image in background, so that only replace the actual tile, once image is loaded in cache!
     var img = new Image();
@@ -36,8 +36,5 @@ class TileLayer2 extends L.TileLayer {
   }
 }
 
-function tileLayer2(url, options) {
-  return new TileLayer2(url, options);
-}
 
-export { TileLayer2, tileLayer2 };
+export { TileLayer };

--- a/src/leaflet/TileLayer.js
+++ b/src/leaflet/TileLayer.js
@@ -1,48 +1,10 @@
 import L from "leaflet";
-import Logger from "../util/Logger";
-// adapted from @barryhunter's implementation:
-// https://github.com/Leaflet/Leaflet/issues/6659#issuecomment-491545545
-// https://gist.github.com/barryhunter/e42f0c4756e34d5d07db4a170c7ec680
+import { redraw } from './Redraw';
+
 
 export default class TileLayer extends L.TileLayer {
-  _refreshTileUrl(tile, url) {
-    //use a image in background, so that only replace the actual tile, once image is loaded in cache!
-    const img = new Image();
-    img.onload = function () {
-      L.Util.requestAnimFrame(function () {
-        tile.el.src = url;
-      });
-    };
-    img.src = url;
-  }
 
   redraw() {
-    Logger.debug(`[TileLayer]: Refreshing tiles`);
-    if(!this._map) {
-      Logger.debug(`[TileLayer]: Map not (yet) loaded, skipping refresh`)
-      return;
-    }
-    //prevent _tileOnLoad/_tileReady re-triggering a opacity animation
-    const wasAnimated = this._map._fadeAnimated;
-    this._map._fadeAnimated = false;
-
-    for (var key in this._tiles) {
-      var tile = this._tiles[key];
-      if (tile.current && tile.active) {
-        const oldsrc = tile.el.src;
-        const newsrc = this.getTileUrl(tile.coords);
-        if (oldsrc != newsrc) {
-          this._refreshTileUrl(tile, newsrc);
-        }
-      }
-    }
-
-    if (wasAnimated) {
-      setTimeout(() => {
-        if(this._map) {
-          this._map._fadeAnimated = wasAnimated;
-        }
-      }, 5000);
-    }
+    redraw(this)
   }
 }

--- a/src/leaflet/TileLayer.test.js
+++ b/src/leaflet/TileLayer.test.js
@@ -1,0 +1,24 @@
+import TileLayer from "./TileLayer";
+import L from 'leaflet';
+import { describe, expect, it } from '@jest/globals';
+
+describe('TileLayer', () => {
+  it('should have a constructor', () => {
+    expect(TileLayer).toBeDefined();
+  });
+
+  it('should inherit from L.TileLayer', () => {
+    const t1 = new TileLayer('url', { key: 'value' });
+    expect(t1 instanceof L.TileLayer).toBe(true);
+
+  });
+
+  it('should have a render method', () => {
+    expect(new TileLayer('url', { key: 'value' }).refresh).toBeDefined();
+  });
+
+
+  it('should have a addTo method', () => {
+    expect(new TileLayer('url', { key: 'value' }).addTo).toBeDefined();
+  });
+});

--- a/src/leaflet/TileLayer.test.js
+++ b/src/leaflet/TileLayer.test.js
@@ -13,12 +13,14 @@ describe('TileLayer', () => {
 
   });
 
-  it('should have a render method', () => {
-    expect(new TileLayer('url', { key: 'value' }).refresh).toBeDefined();
+  it('should have a redraw method', () => {
+    expect(new TileLayer('url', { key: 'value' }).redraw).toBeDefined();
   });
 
 
   it('should have a addTo method', () => {
     expect(new TileLayer('url', { key: 'value' }).addTo).toBeDefined();
   });
+
+
 });

--- a/src/leaflet/WMS.js
+++ b/src/leaflet/WMS.js
@@ -8,38 +8,38 @@ export default class WMS extends L.TileLayer.WMS {
 
   _refreshTileUrl(tile, url) {
     //use a image in background, so that only replace the actual tile, once image is loaded in cache!
-    var img = new Image();
-    img.onload = function() {
-      L.Util.requestAnimFrame(function() {
+    const img = new Image();
+    img.onload = function () {
+      L.Util.requestAnimFrame(function () {
         tile.el.src = url;
       });
-    }
+    };
     img.src = url;
   }
 
   redraw() {
-    Logger.debug(`[WMS]: Refreshing tiles`);
+    Logger.debug(`[TileLayer]: Refreshing tiles`);
     if(!this._map) {
-      Logger.debug(`[WMS]: Map not (yet) loaded, skipping refresh`)
+      Logger.debug(`[TileLayer]: Map not (yet) loaded, skipping refresh`)
       return;
     }
     //prevent _tileOnLoad/_tileReady re-triggering a opacity animation
-    var wasAnimated = this._map?._fadeAnimated;
+    const wasAnimated = this._map._fadeAnimated;
     this._map._fadeAnimated = false;
 
     for (var key in this._tiles) {
       var tile = this._tiles[key];
       if (tile.current && tile.active) {
-        var oldsrc = tile.el.src;
-        var newsrc = this.getTileUrl(tile.coords);
+        const oldsrc = tile.el.src;
+        const newsrc = this.getTileUrl(tile.coords);
         if (oldsrc != newsrc) {
-          this._refreshTileUrl(tile,newsrc);
+          this._refreshTileUrl(tile, newsrc);
         }
       }
     }
 
     if (wasAnimated) {
-      setTimeout(function () {
+      setTimeout(() => {
         if(this._map) {
           this._map._fadeAnimated = wasAnimated;
         }

--- a/src/leaflet/WMS.js
+++ b/src/leaflet/WMS.js
@@ -17,7 +17,7 @@ export default class WMS extends L.TileLayer.WMS {
     img.src = url;
   }
 
-  refresh() {
+  redraw() {
     Logger.debug(`[WMS]: Refreshing tiles`);
     if(!this._map) {
       Logger.debug(`[WMS]: Map not (yet) loaded, skipping refresh`)

--- a/src/leaflet/WMS.js
+++ b/src/leaflet/WMS.js
@@ -1,10 +1,11 @@
+import L from 'leaflet';
+
+
 // adapted from @barryhunter's implementation:
 // https://github.com/Leaflet/Leaflet/issues/6659#issuecomment-491545545
 
-import L from 'leaflet';
+export default class WMS extends L.TileLayer.WMS {
 
-class WMS extends L.TileLayer.WMS {
-  
   _refreshTileUrl(tile, url) {
     //use a image in background, so that only replace the actual tile, once image is loaded in cache!
     var img = new Image();
@@ -22,7 +23,7 @@ class WMS extends L.TileLayer.WMS {
     this._map._fadeAnimated = false;
 
     for (var key in this._tiles) {
-      tile = this._tiles[key];
+      var tile = this._tiles[key];
       if (tile.current && tile.active) {
         var oldsrc = tile.el.src;
         var newsrc = this.getTileUrl(tile.coords);
@@ -33,9 +34,6 @@ class WMS extends L.TileLayer.WMS {
     }
 
     if (wasAnimated)
-      setTimeout(function() { map._fadeAnimated = wasAnimated; }, 5000);
+      setTimeout(function() { this._map._fadeAnimated = wasAnimated; }, 5000);
   }
 }
-
-
-export { WMS };

--- a/src/leaflet/WMS.js
+++ b/src/leaflet/WMS.js
@@ -1,49 +1,9 @@
 import L from 'leaflet';
-import Logger from "../util/Logger";
-
-// adapted from @barryhunter's implementation:
-// https://github.com/Leaflet/Leaflet/issues/6659#issuecomment-491545545
+import { redraw } from './Redraw';
 
 export default class WMS extends L.TileLayer.WMS {
 
-  _refreshTileUrl(tile, url) {
-    //use a image in background, so that only replace the actual tile, once image is loaded in cache!
-    const img = new Image();
-    img.onload = function () {
-      L.Util.requestAnimFrame(function () {
-        tile.el.src = url;
-      });
-    };
-    img.src = url;
-  }
-
   redraw() {
-    Logger.debug(`[TileLayer]: Refreshing tiles`);
-    if(!this._map) {
-      Logger.debug(`[TileLayer]: Map not (yet) loaded, skipping refresh`)
-      return;
-    }
-    //prevent _tileOnLoad/_tileReady re-triggering a opacity animation
-    const wasAnimated = this._map._fadeAnimated;
-    this._map._fadeAnimated = false;
-
-    for (var key in this._tiles) {
-      var tile = this._tiles[key];
-      if (tile.current && tile.active) {
-        const oldsrc = tile.el.src;
-        const newsrc = this.getTileUrl(tile.coords);
-        if (oldsrc != newsrc) {
-          this._refreshTileUrl(tile, newsrc);
-        }
-      }
-    }
-
-    if (wasAnimated) {
-      setTimeout(() => {
-        if(this._map) {
-          this._map._fadeAnimated = wasAnimated;
-        }
-      }, 5000);
-    }
+    redraw(this)
   }
 }

--- a/src/leaflet/WMS.js
+++ b/src/leaflet/WMS.js
@@ -1,5 +1,5 @@
 import L from 'leaflet';
-
+import Logger from "../util/Logger";
 
 // adapted from @barryhunter's implementation:
 // https://github.com/Leaflet/Leaflet/issues/6659#issuecomment-491545545
@@ -18,8 +18,13 @@ export default class WMS extends L.TileLayer.WMS {
   }
 
   refresh() {
+    Logger.debug(`[WMS]: Refreshing tiles`);
+    if(!this._map) {
+      Logger.debug(`[WMS]: Map not (yet) loaded, skipping refresh`)
+      return;
+    }
     //prevent _tileOnLoad/_tileReady re-triggering a opacity animation
-    var wasAnimated = this._map._fadeAnimated;
+    var wasAnimated = this._map?._fadeAnimated;
     this._map._fadeAnimated = false;
 
     for (var key in this._tiles) {
@@ -33,7 +38,12 @@ export default class WMS extends L.TileLayer.WMS {
       }
     }
 
-    if (wasAnimated)
-      setTimeout(function() { this._map._fadeAnimated = wasAnimated; }, 5000);
+    if (wasAnimated) {
+      setTimeout(function () {
+        if(this._map) {
+          this._map._fadeAnimated = wasAnimated;
+        }
+      }, 5000);
+    }
   }
 }

--- a/src/leaflet/WMS.js
+++ b/src/leaflet/WMS.js
@@ -1,0 +1,41 @@
+// adapted from @barryhunter's implementation:
+// https://github.com/Leaflet/Leaflet/issues/6659#issuecomment-491545545
+
+import L from 'leaflet';
+
+class WMS extends L.TileLayer.WMS {
+  
+  _refreshTileUrl(tile, url) {
+    //use a image in background, so that only replace the actual tile, once image is loaded in cache!
+    var img = new Image();
+    img.onload = function() {
+      L.Util.requestAnimFrame(function() {
+        tile.el.src = url;
+      });
+    }
+    img.src = url;
+  }
+
+  refresh() {
+    //prevent _tileOnLoad/_tileReady re-triggering a opacity animation
+    var wasAnimated = this._map._fadeAnimated;
+    this._map._fadeAnimated = false;
+
+    for (var key in this._tiles) {
+      tile = this._tiles[key];
+      if (tile.current && tile.active) {
+        var oldsrc = tile.el.src;
+        var newsrc = this.getTileUrl(tile.coords);
+        if (oldsrc != newsrc) {
+          this._refreshTileUrl(tile,newsrc);
+        }
+      }
+    }
+
+    if (wasAnimated)
+      setTimeout(function() { map._fadeAnimated = wasAnimated; }, 5000);
+  }
+}
+
+
+export { WMS };

--- a/src/leaflet/WMS.test.js
+++ b/src/leaflet/WMS.test.js
@@ -1,0 +1,19 @@
+import WMS from "./WMS";
+import L from 'leaflet';
+import { describe, expect, it } from '@jest/globals';
+
+describe('WMS', () => {
+  it('should have a constructor', () => {
+    expect(WMS).toBeDefined();
+  });
+
+  it('should inherit from L.TileLayer.WMS', () => {
+    const wms = new WMS('url', { key: 'value' });
+    expect(wms instanceof L.TileLayer.WMS).toBe(true);
+  });
+
+  it('should inherit from L.TileLayer', () => {
+    const wms = new WMS('url', { key: 'value' });
+    expect(wms instanceof L.TileLayer).toBe(true);
+  });
+});

--- a/src/models/Layer.js
+++ b/src/models/Layer.js
@@ -2,6 +2,7 @@ import LayerConfig from "../configs/LayerConfig.js";
 import HaUrlResolveService from "../services/HaUrlResolveService.js";
 import Logger from "../util/Logger.js";
 import L from 'leaflet';
+import { TileLayer2, tileLayer2 } from "../util/TileLayer2.js";
 
 export default class Layer {
   
@@ -46,8 +47,8 @@ export default class Layer {
   render() {
     Logger.debug(`[Layer]: Setting up layer of type ${this.layerType}`);
     const layer = this.isWms ? 
-      L.tileLayer.wms(this.url, this.config.options) :
-      L.tileLayer(this.url, this.config.options);
+      tileLayer2.wms(this.url, this.config.options) :
+      tileLayer2(this.url, this.config.options);
     this.urlResolver.registerLayer(layer, this.config.url);
     layer.addTo(this.map);
   }

--- a/src/models/Layer.js
+++ b/src/models/Layer.js
@@ -2,7 +2,8 @@ import LayerConfig from "../configs/LayerConfig.js";
 import HaUrlResolveService from "../services/HaUrlResolveService.js";
 import Logger from "../util/Logger.js";
 import L from 'leaflet';
-import { TileLayer2, tileLayer2 } from "../util/TileLayer2.js";
+import { TileLayer } from "../leaflet/TileLayer.js";
+import { WMS } from "../leaflet/WMS.js";
 
 export default class Layer {
   
@@ -47,8 +48,8 @@ export default class Layer {
   render() {
     Logger.debug(`[Layer]: Setting up layer of type ${this.layerType}`);
     const layer = this.isWms ? 
-      tileLayer2.wms(this.url, this.config.options) :
-      tileLayer2(this.url, this.config.options);
+      new WMS(this.url, this.config.options) :
+      new TileLayer(this.url, this.config.options);
     this.urlResolver.registerLayer(layer, this.config.url);
     layer.addTo(this.map);
   }

--- a/src/models/Layer.js
+++ b/src/models/Layer.js
@@ -1,9 +1,9 @@
 import LayerConfig from "../configs/LayerConfig.js";
 import HaUrlResolveService from "../services/HaUrlResolveService.js";
 import Logger from "../util/Logger.js";
-import L from 'leaflet';
-import { TileLayer } from "../leaflet/TileLayer.js";
-import { WMS } from "../leaflet/WMS.js";
+import Map from 'leaflet';
+import TileLayer from "../leaflet/TileLayer.js";
+import WMS from "../leaflet/WMS.js";
 
 export default class Layer {
   
@@ -11,7 +11,7 @@ export default class Layer {
   layerType;
   /** @type {LayerConfig} */
   config;
-  /** @type {L.map} */
+  /** @type {Map} */
   map;
   /** @type {HaUrlResolveService} */
   urlResolver;
@@ -19,7 +19,7 @@ export default class Layer {
   /**
    * @param {string} layerType 
    * @param {object} config 
-   * @param {L.map} map 
+   * @param {Map} map 
    * @param {HaUrlResolveService} urlResolver 
    */
   constructor(layerType, config, map, urlResolver) {
@@ -50,6 +50,7 @@ export default class Layer {
     const layer = this.isWms ? 
       new WMS(this.url, this.config.options) :
       new TileLayer(this.url, this.config.options);
+
     this.urlResolver.registerLayer(layer, this.config.url);
     layer.addTo(this.map);
   }

--- a/src/models/Layer.test.js
+++ b/src/models/Layer.test.js
@@ -6,32 +6,17 @@ import HaUrlResolveService from "../services/HaUrlResolveService.js";
 import Logger from "../util/Logger.js";
 import L from 'leaflet';
 
-
 jest.mock('../services/HaUrlResolveService.js');
 jest.mock('../util/Logger.js');
-jest.mock('leaflet', () => ({
-  map: jest.fn(),
-  tileLayer: jest.fn(() => ({
-    addTo: jest.fn(),
-    wms: jest.fn(() => ({
-      addTo: jest.fn(),
-    })),
-  })),
-  default: {    
-    tileLayer: jest.fn(() => ({
-      addTo: jest.fn(),
-      wms: jest.fn(() => ({
-        addTo: jest.fn(),
-      })),
-    })),
-  },
-}));
+
 
 describe('Layer', () => {
   let mockMap, mockUrlResolver, mockConfig;
 
   beforeEach(() => {
-    mockMap = L.map();
+    mockMap = {
+      addLayer: jest.fn(),
+    };    
     mockUrlResolver = new HaUrlResolveService();
     mockConfig = new LayerConfig({
       url: 'test-url',
@@ -75,16 +60,22 @@ describe('Layer', () => {
     expect(mockUrlResolver.resolveUrl).toHaveBeenCalledWith(mockConfig.url);
   });
 
-  it('should setup a WMS layer correctly', () => {
-
-  });
-
   it('should setup a Tile layer correctly', () => {
     const layer = new Layer('tile', mockConfig, mockMap, mockUrlResolver);
     layer.render();
 
     expect(Logger.debug).toHaveBeenCalledWith('[Layer]: Setting up layer of type tile');
     expect(mockUrlResolver.registerLayer).toHaveBeenCalledWith(expect.any(Object), mockConfig.url);
+    expect(mockMap.addLayer).toHaveBeenCalledWith(expect.any(L.TileLayer));
+  });
+
+  it('should setup a WMS layer correctly', () => {
+    const layer = new Layer('wms', mockConfig, mockMap, mockUrlResolver);
+    layer.render();
+
+    expect(Logger.debug).toHaveBeenCalledWith('[Layer]: Setting up layer of type wms');
+    expect(mockUrlResolver.registerLayer).toHaveBeenCalledWith(expect.any(Object), mockConfig.url);
+    expect(mockMap.addLayer).toHaveBeenCalledWith(expect.any(L.TileLayer));
 
   });
 });

--- a/src/models/Layer.test.js
+++ b/src/models/Layer.test.js
@@ -1,13 +1,90 @@
-import Layer from "./Layer";
-import {describe, expect, it} from "@jest/globals";
+// Import necessary modules
+import { describe, it, beforeEach, afterEach, expect, jest } from '@jest/globals';
+import Layer from './Layer.js';
+import LayerConfig from "../configs/LayerConfig.js";
+import HaUrlResolveService from "../services/HaUrlResolveService.js";
+import Logger from "../util/Logger.js";
+import L from 'leaflet';
 
-describe("Layer", () => {
-  it("should have a constructor", () => {
-    expect(Layer).toBeDefined();
+
+jest.mock('../services/HaUrlResolveService.js');
+jest.mock('../util/Logger.js');
+jest.mock('leaflet', () => ({
+  map: jest.fn(),
+  tileLayer: jest.fn(() => ({
+    addTo: jest.fn(),
+    wms: jest.fn(() => ({
+      addTo: jest.fn(),
+    })),
+  })),
+  default: {    
+    tileLayer: jest.fn(() => ({
+      addTo: jest.fn(),
+      wms: jest.fn(() => ({
+        addTo: jest.fn(),
+      })),
+    })),
+  },
+}));
+
+describe('Layer', () => {
+  let mockMap, mockUrlResolver, mockConfig;
+
+  beforeEach(() => {
+    mockMap = L.map();
+    mockUrlResolver = new HaUrlResolveService();
+    mockConfig = new LayerConfig({
+      url: 'test-url',
+      options: { some: 'option' }
+    });
   });
 
-  it("should have a render method", () => {
-    expect(new Layer().render).toBeDefined();
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
+  it('should initialize with correct properties', () => {
+    const layer = new Layer('wms', mockConfig, mockMap, mockUrlResolver);
+    expect(layer.layerType).toBe('wms');
+    expect(layer.config).toBe(mockConfig);
+    expect(layer.map).toBe(mockMap);
+    expect(layer.urlResolver).toBe(mockUrlResolver);
+  });
+
+  it('should recognize WMS layer type', () => {
+    const layer = new Layer('wms', mockConfig, mockMap, mockUrlResolver);
+    expect(layer.isWms).toBe(true);
+    expect(layer.isTileLayer).toBe(false);
+  });
+
+  it('should recognize tile layer type', () => {
+    const layer = new Layer('tile', mockConfig, mockMap, mockUrlResolver);
+    expect(layer.isWms).toBe(false);
+    expect(layer.isTileLayer).toBe(true);
+  });
+
+  it('should return config options', () => {
+    const layer = new Layer('wms', mockConfig, mockMap, mockUrlResolver);
+    expect(layer.options).toBe(mockConfig.options);
+  });
+
+  it('should resolve URL with urlResolver', () => {
+    mockUrlResolver.resolveUrl = jest.fn(() => 'resolved-url');
+    const layer = new Layer('wms', mockConfig, mockMap, mockUrlResolver);
+    expect(layer.url).toBe('resolved-url');
+    expect(mockUrlResolver.resolveUrl).toHaveBeenCalledWith(mockConfig.url);
+  });
+
+  it('should setup a WMS layer correctly', () => {
+
+  });
+
+  it('should setup a Tile layer correctly', () => {
+    const layer = new Layer('tile', mockConfig, mockMap, mockUrlResolver);
+    layer.render();
+
+    expect(Logger.debug).toHaveBeenCalledWith('[Layer]: Setting up layer of type tile');
+    expect(mockUrlResolver.registerLayer).toHaveBeenCalledWith(expect.any(Object), mockConfig.url);
+
+  });
 });

--- a/src/models/LayerWithHistory.js
+++ b/src/models/LayerWithHistory.js
@@ -3,9 +3,9 @@ import HaMapUtilities from "../util/HaMapUtilities.js";
 import Layer from "./Layer.js";
 import HaLinkedEntityService from "../services/HaLinkedEntityService.js";
 import HaDateRangeService from "../services/HaDateRangeService.js";
-import L from 'leaflet';
-import { TileLayer } from "../leaflet/TileLayer.js";
-import { WMS } from "../leaflet/WMS.js";
+import Map from 'leaflet';
+import TileLayer from "../leaflet/TileLayer.js";
+import WMS from "../leaflet/WMS.js";
 import HaUrlResolveService from "../services/HaUrlResolveService.js";
 
 export default class LayerWithHistory extends Layer {
@@ -14,14 +14,14 @@ export default class LayerWithHistory extends Layer {
   linkedEntityService;
   /** @type {HaDateRangeService} */
   dateRangeManager;
-  /** @type {L.TileLayer} */
+  /** @type {TileLayer} */
   layer;
 
   /**
    * 
    * @param {string} layerType 
    * @param {object} config 
-   * @param {L.map} map 
+   * @param {Map} map 
    * @param {HaUrlResolveService} urlResolver 
    * @param {HaLinkedEntityService} linkedEntityService 
    * @param {HaDateRangeService} dateRangeManager 

--- a/src/models/LayerWithHistory.js
+++ b/src/models/LayerWithHistory.js
@@ -4,6 +4,7 @@ import Layer from "./Layer.js";
 import HaLinkedEntityService from "../services/HaLinkedEntityService.js";
 import HaDateRangeService from "../services/HaDateRangeService.js";
 import L from 'leaflet';
+import { TileLayer2, tileLayer2 } from "../util/TileLayer2.js";
 import HaUrlResolveService from "../services/HaUrlResolveService.js";
 
 export default class LayerWithHistory extends Layer {
@@ -42,8 +43,8 @@ export default class LayerWithHistory extends Layer {
 
     // Draw our new layer
     let newLayer = this.isWms ? 
-      L.tileLayer.wms(this.url, this.options).addTo(this.map) :
-      L.tileLayer(this.url, this.options).addTo(this.map);
+      tileLayer2.wms(this.url, this.options).addTo(this.map) :
+      tileLayer2(this.url, this.options).addTo(this.map);
 
     // When its ready, remove the old one.
     newLayer.on('load', () => {

--- a/src/models/LayerWithHistory.js
+++ b/src/models/LayerWithHistory.js
@@ -4,7 +4,8 @@ import Layer from "./Layer.js";
 import HaLinkedEntityService from "../services/HaLinkedEntityService.js";
 import HaDateRangeService from "../services/HaDateRangeService.js";
 import L from 'leaflet';
-import { TileLayer2, tileLayer2 } from "../util/TileLayer2.js";
+import { TileLayer } from "../leaflet/TileLayer.js";
+import { WMS } from "../leaflet/WMS.js";
 import HaUrlResolveService from "../services/HaUrlResolveService.js";
 
 export default class LayerWithHistory extends Layer {
@@ -43,8 +44,8 @@ export default class LayerWithHistory extends Layer {
 
     // Draw our new layer
     let newLayer = this.isWms ? 
-      tileLayer2.wms(this.url, this.options).addTo(this.map) :
-      tileLayer2(this.url, this.options).addTo(this.map);
+      new WMS(this.url, this.options).addTo(this.map) :
+      new TileLayer(this.url, this.options).addTo(this.map);
 
     // When its ready, remove the old one.
     newLayer.on('load', () => {

--- a/src/models/LayerWithHistory.test.js
+++ b/src/models/LayerWithHistory.test.js
@@ -5,29 +5,19 @@ import HaUrlResolveService from "../services/HaUrlResolveService.js";
 import HaLinkedEntityService from "../services/HaLinkedEntityService.js";
 import HaDateRangeService from "../services/HaDateRangeService.js";
 
-import L from 'leaflet';
-
-
-// Mock dependencies
-
 jest.mock('../services/HaUrlResolveService.js');
 jest.mock('../services/HaLinkedEntityService.js');
 jest.mock('../services/HaDateRangeService.js');
 
 
-jest.mock('leaflet', () => ({
-  map: jest.fn(),
-  tileLayer: jest.fn(() => ({ 
-    addTo: jest.fn(() => ({ on: jest.fn() })), 
-    wms: jest.fn(() => ({ addTo: jest.fn(() => ({ on: jest.fn() })) }))
-  })),
-}));
 
 describe("LayerWithHistory", () => {
   let mockMap, mockUrlResolver, mockLinkedEntityService, mockDateRangeManager, mockConfig;
 
   beforeEach(() => {
-    mockMap = L.map();
+    mockMap = {
+      addLayer: jest.fn(),
+    }; 
     mockUrlResolver = new HaUrlResolveService();
     mockLinkedEntityService = new HaLinkedEntityService();
     mockDateRangeManager = new HaDateRangeService();

--- a/src/models/LayerWithHistory.test.js
+++ b/src/models/LayerWithHistory.test.js
@@ -1,8 +1,50 @@
+import { describe, it, beforeEach, afterEach, expect, jest } from '@jest/globals';
 import LayerConfig from "../configs/LayerConfig";
 import LayerWithHistory from "./LayerWithHistory";  
-import {describe, expect, it, jest} from "@jest/globals";
+import HaUrlResolveService from "../services/HaUrlResolveService.js";
+import HaLinkedEntityService from "../services/HaLinkedEntityService.js";
+import HaDateRangeService from "../services/HaDateRangeService.js";
+
+import L from 'leaflet';
+
+
+// Mock dependencies
+
+jest.mock('../services/HaUrlResolveService.js');
+jest.mock('../services/HaLinkedEntityService.js');
+jest.mock('../services/HaDateRangeService.js');
+
+
+jest.mock('leaflet', () => ({
+  map: jest.fn(),
+  tileLayer: jest.fn(() => ({ 
+    addTo: jest.fn(() => ({ on: jest.fn() })), 
+    wms: jest.fn(() => ({ addTo: jest.fn(() => ({ on: jest.fn() })) }))
+  })),
+}));
 
 describe("LayerWithHistory", () => {
+  let mockMap, mockUrlResolver, mockLinkedEntityService, mockDateRangeManager, mockConfig;
+
+  beforeEach(() => {
+    mockMap = L.map();
+    mockUrlResolver = new HaUrlResolveService();
+    mockLinkedEntityService = new HaLinkedEntityService();
+    mockDateRangeManager = new HaDateRangeService();
+    mockConfig = {
+      historyForceMidnight: true,
+      historyProperty: 'TIME',
+      historySource: 'auto',
+      url: 'test-url',
+      historyStart: { entity: 'history_entity' },
+      historySourceSuffix: 'suffix',
+      options: {}
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
   it("should have a constructor", () => {
     expect(LayerWithHistory).toBeDefined();
@@ -11,6 +53,26 @@ describe("LayerWithHistory", () => {
   it("should have a render method", () => {
     expect(new LayerWithHistory('tile', new LayerConfig(), {}, {}, {}, {} ).render).toBeDefined();
   });
+
+  it('should if historyForceMidnight is set, set it to midnight', () => {
+    const layerWithHistory = new LayerWithHistory('wms', mockConfig, mockMap, mockUrlResolver, mockLinkedEntityService, mockDateRangeManager);
+    const date = new Date('2023-10-05T14:48:00Z');
+    layerWithHistory.updateLayer(date);
+
+    expect(date.getUTCHours()).toBe(0);
+    expect(date.getUTCMinutes()).toBe(0);
+    expect(date.getUTCSeconds()).toBe(0);
+    expect(date.getUTCMilliseconds()).toBe(0);
+  });
+
+  it('should if a historyStart entity is defined, use the LinkedEntityService', () => {
+    mockConfig.historyStart = { entity: 'some_entity' };
+    const layerWithHistory = new LayerWithHistory('wms', mockConfig, mockMap, mockUrlResolver, mockLinkedEntityService, null);
+    layerWithHistory.render();
+
+    expect(mockLinkedEntityService.onStateChange).toHaveBeenCalledWith('some_entity', expect.any(Function));
+  });
+
 
   it("should update the layer if there is a new date from the DateRangeManager", () => {
       

--- a/src/services/HaUrlResolveService.js
+++ b/src/services/HaUrlResolveService.js
@@ -94,11 +94,8 @@ class EntityLayers {
     this.layers.forEach(layer => {
       const url = this.urlResolver.resolveUrl(layer.urlTemplate);
       Logger.debug(`[HaUrlResolveService]: Updating layer ${layer.urlTemplate} to ${url}`);
-
-      // setting the second argument stops the built-in redraw() of TileLayer,
-      // since we wish to use our own refresh() function instead
-      layer.layer.setUrl(url, true);
-      layer.layer.refresh();
+      
+      layer.layer.setUrl(url);
     });
   }
 }

--- a/src/services/HaUrlResolveService.js
+++ b/src/services/HaUrlResolveService.js
@@ -93,8 +93,11 @@ class EntityLayers {
   update() {
     this.layers.forEach(layer => {
       Logger.debug(`[HaUrlResolveService]: Updating layer ${layer.layer}`);
-      layer.layer.setUrl(this.urlResolver.resolveUrl(layer.urlTemplate));
-      layer.layer.redraw();
+
+      // setting the second argument stops the built-in redraw() of TileLayer,
+      // since we wish to use our own refresh() function instead
+      layer.layer.setUrl(this.urlResolver.resolveUrl(layer.urlTemplate), true);
+      layer.layer.refresh();
     });
   }
 }

--- a/src/services/HaUrlResolveService.js
+++ b/src/services/HaUrlResolveService.js
@@ -92,11 +92,12 @@ class EntityLayers {
 
   update() {
     this.layers.forEach(layer => {
-      Logger.debug(`[HaUrlResolveService]: Updating layer ${layer.layer}`);
+      const url = this.urlResolver.resolveUrl(layer.urlTemplate);
+      Logger.debug(`[HaUrlResolveService]: Updating layer ${layer.urlTemplate} to ${url}`);
 
       // setting the second argument stops the built-in redraw() of TileLayer,
       // since we wish to use our own refresh() function instead
-      layer.layer.setUrl(this.urlResolver.resolveUrl(layer.urlTemplate), true);
+      layer.layer.setUrl(url, true);
       layer.layer.refresh();
     });
   }

--- a/src/util/TileLayer2.js
+++ b/src/util/TileLayer2.js
@@ -1,0 +1,43 @@
+// adapted from @barryhunter's implementation:
+// https://github.com/Leaflet/Leaflet/issues/6659#issuecomment-491545545
+
+import L from 'leaflet';
+
+class TileLayer2 extends L.TileLayer {
+  _refreshTileUrl(tile, url) {
+    //use a image in background, so that only replace the actual tile, once image is loaded in cache!
+    var img = new Image();
+    img.onload = function() {
+      L.Util.requestAnimFrame(function() {
+        tile.el.src = url;
+      });
+    }
+    img.src = url;
+  }
+
+  refresh() {
+    //prevent _tileOnLoad/_tileReady re-triggering a opacity animation
+    var wasAnimated = this._map._fadeAnimated;
+    this._map._fadeAnimated = false;
+
+    for (var key in this._tiles) {
+      tile = this._tiles[key];
+      if (tile.current && tile.active) {
+        var oldsrc = tile.el.src;
+        var newsrc = this.getTileUrl(tile.coords);
+        if (oldsrc != newsrc) {
+          this._refreshTileUrl(tile,newsrc);
+        }
+      }
+    }
+
+    if (wasAnimated)
+      setTimeout(function() { map._fadeAnimated = wasAnimated; }, 5000);
+  }
+}
+
+function tileLayer2(url, options) {
+  return new TileLayer2(url, options);
+}
+
+export { TileLayer2, tileLayer2 };


### PR DESCRIPTION
I was testing the changes from #102 with a template sensor that cycles through the URLs for a time series of weather radar data from the rainviewer radar api [as seen in my comment here](https://github.com/nathan-gs/ha-map-card/issues/48#issuecomment-2574562533). I noticed the annoying flicker/fade effect when the URL for a `tileLayer` is updated. Here is what it looks like.

https://github.com/user-attachments/assets/02892285-6eb7-42aa-8dc7-e600d539bede

This appears to be a well known issue and @barryhunter has a solution over on his issue in the leaflet repository: https://github.com/Leaflet/Leaflet/issues/6659#issuecomment-491545545

I have pretty much copied over his `TileLayer2` and swapped over to it wherever `tileLayer` was previously used. With these changes and an identical configuration for the card, it now looks like:

https://github.com/user-attachments/assets/bc7f375c-5702-4cb4-9efa-8514061057a8

IMO, this is much nicer. Has not been tested with a `wms` source. I am a javascript novice, so feel free to move things around as you see fit :)


