### PR TITLE
implement plugin system for adding complex functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ plugins:
 | [`bom-radar`](https://github.com/bezmi/ha-map-card-plugin-bom-radar) | Displays the Australian BoM rainfall radar for the past 90 minutes and the radar forecast for the next 90 minutes as an overlay on the map. | 
 | [`buienradar`](https://github.com/Kevinjil/ha-map-card-buienradar) | Displays `buienradar.nl` as an overlay on the map | 
 
-
+You can find more plugins using the [ha-map-card-plugin](https://github.com/topics/ha-map-card-plugin) topic.
 
 ## Extra Tile Layers
 
@@ -235,6 +235,8 @@ This project uses [devenv.sh](https://devenv.sh/).
 * All plugins should implement the `Plugin` class. See [`Plugin.js`](./src/models/Plugin.js) and [`Plugin.d.ts`](./src/models/Plugin.d.ts).
 * For a concrete example, see [`CircleTestPlugin.js`](./plugins/CircleTestPlugin.js).
 * Typescript example: see [bezmi/ha-map-card-plugin-bom-radar](https://github.com/bezmi/ha-map-card-plugin-bom-radar).
+
+Tag your Github repo with [ha-map-card-plugin](https://github.com/topics/ha-map-card-plugin) for discoverability.
 
 
 ## Mentions & Discussions

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ y: 3.652
 | `follow_focus`        | none                                  | `none`, `refocus`, `contains`, reset the map focused entity's, on each update.                                                               |
 | `map_options`          | {}                                                                                                                           | The `options` for the default [Leaflet Map](https://leafletjs.com/reference.html#map) |
 | `debug` | false                                                                                                                        | Enable debug messages in console.
+| `plugins`            | []                                                                                                                           | An array of plugin definitions, see: [Plugin Options](#plugin-options) and [Available plugins](#available-plugins)     |
 
 
 If `x` & `y` or `focus_entity` is not set it will take the lat/long from the __first entity__.
@@ -151,6 +152,38 @@ Source
 | `options` | The leaflet layer [WMS options](https://leafletjs.com/reference.html#tilelayer-wms) or [Tile Layer options](https://leafletjs.com/reference.html#tilelayer) |
 | `history` | The name of the layer option which controls the dat, if it supports a date or time option. Set history to the name of this property. The `history_start` value, state or date range picker will then set this property on the layer and update it as necessary. |
 
+### Plugin options
+| name      | note                                                                                                                                                        |
+|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`  | Mandatory, a helpful name for this instance of the plugin. Useful for debugging issues. |
+| `url`     | Mandatory, The url of the plugin, if the plugin is in the file `/var/lib/hass/www/SomePlugin.js` , then this would be `./local/SomePlugin.js`. |
+| `options` | Options for configuring the plugin |
+
+
+
+#### Example config with plugin
+```yaml
+type: custom:map-card
+x: -25.3744
+y: 133.7751
+plugins:
+  - name: plugin
+    url: /local/my-plugin.js
+    options:
+      some_option: true
+  - name: another_instance
+    url: /local/my-plugin.js
+    options:
+      some_option: false
+```
+
+#### Available Plugins
+| name      | description                                                                                         |
+|-----------|-----------------------------------------------------------------------------------------------------|
+| [`bom-radar`](https://github.com/bezmi/ha-map-card-plugin-bom-radar) | Displays the Australian BoM rainfall radar for the past 90 minutes and the radar forecast for the next 90 minutes as an overlay on the map. | 
+| [`buienradar`](https://github.com/Kevinjil/ha-map-card-buienradar) | Displays `buienradar.nl` as an overlay on the map | 
+
+
 #### Zooming & `tile_layer_options.maxZoom`
 
 By default the map-card will not zoom beyond [default property of the `maxZoom`](https://leafletjs.com/reference.html#tilelayer-maxzoom) of the tilelayer, the default is `18`, but it can be overriden as follows:
@@ -198,6 +231,10 @@ This project uses [devenv.sh](https://devenv.sh/).
 * `npm install`
 * `npm run build` (`npm run watch` to update on change)
 
+### Developing Plugins
+* All plugins should implement the `Plugin` class. See [`Plugin.js`](./src/models/Plugin.js) and [`Plugin.d.ts`](./src/models/Plugin.d.ts).
+* For a concrete example, see [`CircleTestPlugin.js`](./plugins/CircleTestPlugin.js).
+* Typescript example: see [bezmi/ha-map-card-plugin-bom-radar](https://github.com/bezmi/ha-map-card-plugin-bom-radar).
 
 
 ## Mentions & Discussions

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ y: 3.652
 | `follow_focus`        | none                                  | `none`, `refocus`, `contains`, reset the map focused entity's, on each update.                                                               |
 | `map_options`          | {}                                                                                                                           | The `options` for the default [Leaflet Map](https://leafletjs.com/reference.html#map) |
 | `debug` | false                                                                                                                        | Enable debug messages in console.
-| `plugins`            | []                                                                                                                           | An array of plugin definitions, see: [Plugin Options](#plugin-options) and [Available plugins](#available-plugins)     |
+| `plugins`            | []                                                                                                                           | An array of plugin definitions, see: [Plugin Options](#plugin-options), [Available plugins](#available-plugins) and [Developing plugins](#developing-plugins)     |
 
 
 If `x` & `y` or `focus_entity` is not set it will take the lat/long from the __first entity__.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,34 @@ Source
 | `options` | The leaflet layer [WMS options](https://leafletjs.com/reference.html#tilelayer-wms) or [Tile Layer options](https://leafletjs.com/reference.html#tilelayer) |
 | `history` | The name of the layer option which controls the dat, if it supports a date or time option. Set history to the name of this property. The `history_start` value, state or date range picker will then set this property on the layer and update it as necessary. |
 
+#### Zooming & `tile_layer_options.maxZoom`
+
+By default the map-card will not zoom beyond [default property of the `maxZoom`](https://leafletjs.com/reference.html#tilelayer-maxzoom) of the tilelayer, the default is `18`, but it can be overriden as follows:
+
+```
+type: custom:map-card
+tile_layer_options:
+  maxZoom: 20
+```
+
+Keep in mind that the tile layer source also has a maximum zoom level, which is `20` for most OSM maps.
+
+#### Advanced WMS/Tile layer options
+
+More complex use of the WMS/Tile history property can be configured within the history property of the layer.
+* `property` is the option this should control (often named `time` or `date`)
+* `source` defaults to auto (which means it will inherit from the main map settings). Set this to a date or number entity if this is different.
+* `suffix` days ago/weeks ago as with other history entities
+* `force_midnight` some WMS/Tile layers only work if the date is set as midnight.
+
+```
+  history:
+    property: time
+    source: input_number.test_number_value
+    suffix: months ago
+    force_midnight: true
+```
+
 ### Plugin options
 | name      | note                                                                                                                                                        |
 |-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -183,34 +211,6 @@ plugins:
 | [`bom-radar`](https://github.com/bezmi/ha-map-card-plugin-bom-radar) | Displays the Australian BoM rainfall radar for the past 90 minutes and the radar forecast for the next 90 minutes as an overlay on the map. | 
 | [`buienradar`](https://github.com/Kevinjil/ha-map-card-buienradar) | Displays `buienradar.nl` as an overlay on the map | 
 
-
-#### Zooming & `tile_layer_options.maxZoom`
-
-By default the map-card will not zoom beyond [default property of the `maxZoom`](https://leafletjs.com/reference.html#tilelayer-maxzoom) of the tilelayer, the default is `18`, but it can be overriden as follows:
-
-```
-type: custom:map-card
-tile_layer_options:
-  maxZoom: 20
-```
-
-Keep in mind that the tile layer source also has a maximum zoom level, which is `20` for most OSM maps.
-
-#### Advanced WMS/Tile layer options
-
-More complex use of the WMS/Tile history property can be configured within the history property of the layer.
-* `property` is the option this should control (often named `time` or `date`)
-* `source` defaults to auto (which means it will inherit from the main map settings). Set this to a date or number entity if this is different.
-* `suffix` days ago/weeks ago as with other history entities
-* `force_midnight` some WMS/Tile layers only work if the date is set as midnight.
-
-```
-  history:
-    property: time
-    source: input_number.test_number_value
-    suffix: months ago
-    force_midnight: true
-```
 
 
 ## Extra Tile Layers

--- a/plugins/CircleTestPlugin.js
+++ b/plugins/CircleTestPlugin.js
@@ -12,17 +12,21 @@ export default function(L, pluginBase) {
       this.y = y
       this.r = r;
       this.circle_options = circle_options;
-      console.log("Successfully invoked constructor of plugin:", this.name, "with options:", this.options);
+      console.debug("[HaMapCard] [CircleTestPlugin] Successfully invoked constructor of plugin:", this.name, "with options:", this.options);
     }
 
     init() {
-      console.log("Called init() of plugin:", this.name);
+      console.debug("[HaMapCard] [CircleTestPlugin] Called init() of plugin:", this.name);
     }
 
-    render() {
-      console.log('Called render() of Plugin:', this.name);
+    renderMap() {
+      console.debug("[HaMapCard] [CircleTestPlugin] Called render() of Plugin:", this.name);
       L.circle([this.x, this.y], { radius: this.r, ...this.circle_options }).addTo(this.map);
 
+    }
+
+    update() {
+      console.debug("[HaMapCard] [CircleTestPlugin] Called update() of Plugin:", this.name);
     }
   };
 }

--- a/plugins/CircleTestPlugin.js
+++ b/plugins/CircleTestPlugin.js
@@ -14,7 +14,7 @@ export default function (L, pluginBase) {
       console.log("Called init() of plugin:", this.name);
     }
 
-    render() {
+    renderMap() {
       console.log('Called render() of Plugin:', this.name);
       L.circle([this.x, this.y], { radius: this.r, ...this.circle_options }).addTo(this.map);
 

--- a/plugins/CircleTestPlugin.js
+++ b/plugins/CircleTestPlugin.js
@@ -2,8 +2,9 @@
  *
  * @param L
  * @param pluginBase
+ * @param Logger
  */
-export default function(L, pluginBase) {
+export default function(L, pluginBase, Logger) {
   return class CircleTestPlugin extends pluginBase {
     constructor(map, name, options = {}) {
       super(map, name, options);
@@ -12,21 +13,26 @@ export default function(L, pluginBase) {
       this.y = y
       this.r = r;
       this.circle_options = circle_options;
-      console.debug("[HaMapCard] [CircleTestPlugin] Successfully invoked constructor of plugin:", this.name, "with options:", this.options);
+      Logger.debug(`[CircleTestPlugin] Successfully invoked constructor of plugin: ${this.name} with options: ${this.options}`);
     }
 
     init() {
-      console.debug("[HaMapCard] [CircleTestPlugin] Called init() of plugin:", this.name);
+      Logger.debug(`[CircleTestPlugin] Called init() of plugin: ${this.name}`);
     }
 
     renderMap() {
-      console.debug("[HaMapCard] [CircleTestPlugin] Called render() of Plugin:", this.name);
-      L.circle([this.x, this.y], { radius: this.r, ...this.circle_options }).addTo(this.map);
+      Logger.debug(`[CircleTestPlugin] Called render() of Plugin: ${this.name}`);
+      this.circle = L.circle([this.x, this.y], { radius: this.r, ...this.circle_options }).addTo(this.map);
 
     }
 
     update() {
-      console.debug("[HaMapCard] [CircleTestPlugin] Called update() of Plugin:", this.name);
+      Logger.debug(`[CircleTestPlugin] Called update() of Plugin: ${this.name}`);
+    }
+
+    destroy() {
+      Logger.debug(`[CircleTestPlugin] Called destroy() of Plugin: ${this.name}`);
+      this.circle.remove();
     }
   };
 }

--- a/plugins/CircleTestPlugin.js
+++ b/plugins/CircleTestPlugin.js
@@ -1,4 +1,9 @@
-export default function (L, pluginBase) {
+/**
+ *
+ * @param L
+ * @param pluginBase
+ */
+export default function(L, pluginBase) {
   return class CircleTestPlugin extends pluginBase {
     constructor(map, name, options = {}) {
       super(map, name, options);
@@ -14,7 +19,7 @@ export default function (L, pluginBase) {
       console.log("Called init() of plugin:", this.name);
     }
 
-    renderMap() {
+    render() {
       console.log('Called render() of Plugin:', this.name);
       L.circle([this.x, this.y], { radius: this.r, ...this.circle_options }).addTo(this.map);
 

--- a/src/CircleTestPlugin.js
+++ b/src/CircleTestPlugin.js
@@ -1,0 +1,23 @@
+export default function (L, pluginBase) {
+  return class CircleTestPlugin extends pluginBase {
+    constructor(map, name, options = {}) {
+      super(map, name, options);
+      const { x, y, r, ...circle_options } = options
+      this.x = x;
+      this.y = y
+      this.r = r;
+      this.circle_options = circle_options;
+      console.log("Successfully invoked constructor of plugin:", this.name, "with options:", this.options);
+    }
+
+    init() {
+      console.log("Called init() of plugin:", this.name);
+    }
+
+    render() {
+      console.log('Called render() of Plugin:', this.name);
+      L.circle([this.x, this.y], { radius: this.r, ...this.circle_options }).addTo(this.map);
+
+    }
+  };
+}

--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -45,7 +45,7 @@ export default class MapCard extends LitElement {
   /** @type {InitialViewRenderService} */
   initialViewRenderService;
   /** @type {PluginsRenderService} */
-  pluginManager;
+  pluginsRenderService;
   hasError = false;
   hadError = false;
 
@@ -206,6 +206,7 @@ export default class MapCard extends LitElement {
     this.historyService?.unsubscribe();
     this.dateRangeManager?.disconnect();
     this.linkedEntityService?.disconnect();
+    this.pluginsRenderService?.cleanup();
   }
 
   _isDarkMode() {

--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -44,7 +44,7 @@ export default class MapCard extends LitElement {
   entitiesRenderService;
   /** @type {InitialViewRenderService} */
   initialViewRenderService;
-  /** @type {PluginManager} */
+  /** @type {PluginsRenderService} */
   pluginManager;
   hasError = false;
   hadError = false;

--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -12,6 +12,7 @@ import TileLayersService from '../services/render/TileLayersRenderService.js';
 import EntitiesRenderService from '../services/render/EntitiesRenderService.js';
 import InitialViewRenderService from '../services/render/InitialViewRenderService.js';
 import TileLayer from '../leaflet/TileLayer.js';
+import PluginsRenderService from '../services/render/PluginsRenderService.js';
 
 export default class MapCard extends LitElement {
   static get properties() {
@@ -21,7 +22,7 @@ export default class MapCard extends LitElement {
     };
   }
 
-  setupNeeded = true;  
+  setupNeeded = true;
   /** @type {L.Map} */
   map;
   resizeObserver;
@@ -43,33 +44,39 @@ export default class MapCard extends LitElement {
   entitiesRenderService;
   /** @type {InitialViewRenderService} */
   initialViewRenderService;
+  /** @type {PluginManager} */
+  pluginManager;
   hasError = false;
   hadError = false;
 
   setup() {
     Logger.debug("[MapCard] Setting up map card");
+
     this.themeMode = this._config.themeMode;
     this.map = this._setupMap();
     // redraw the map every time it resizes
     this.resizeObserver = this._setupResizeObserver();
-    
+
     // Setup core history service
     this.historyService = new HaHistoryService(this.hass);
     // Is history date range enabled?
     if (this._config.historyDateSelection) {
       this.dateRangeManager = new HaDateRangeService(this.hass);
-    }    
+    }
     this.tileLayersService = new TileLayersService(this.map, this._config.tileLayers, this._config.wms, this.urlResolver, this.linkedEntityService, this.dateRangeManager);
     this.entitiesRenderService = new EntitiesRenderService(this.map, this.hass, this._config.entities, this.linkedEntityService, this.dateRangeManager, this.historyService, this._isDarkMode());
     this.initialViewRenderService = new InitialViewRenderService(this.map, this._config, this.hass, this.entitiesRenderService);
-  
+
+    this.pluginsRenderService = new PluginsRenderService(this.map, this._config.plugins);
+
     try {
+      this.pluginsRenderService.setup();
       this.tileLayersService.setup();
       this.entitiesRenderService.setup();
       this.initialViewRenderService.setup();
 
       this.setupNeeded = false;
-      this.render();          
+      this.render();
       this.hasError = false;
     } catch (e) {
       this.hasError = true;
@@ -80,22 +87,22 @@ export default class MapCard extends LitElement {
     Logger.debug("[MapCard] Map card setup complete");
   }
 
-  firstUpdated() {    
+  firstUpdated() {
     this.setup();
   };
 
-
   render() {
-    
+
     if (this.map) {
       if (this.setupNeeded) {
         this.setup();
       }
+      this.pluginsRenderService.render();
       this.tileLayersService.render();
       this.entitiesRenderService.render();
       this.initialViewRenderService.render();
 
-      if(!this.hasError && this.hadError) {
+      if (!this.hasError && this.hadError) {
         HaMapUtilities.removeWarningOnMap(this.map, "Error found, check Console");
         HaMapUtilities.removeWarningOnMap(this.map, "Error found in first run, check Console");
         this.hadError = false;
@@ -145,9 +152,9 @@ export default class MapCard extends LitElement {
   /** @returns {L.Map} Leaflet Map */
   _setupMap() {
     // Manages watching external entities.
-    this.linkedEntityService = new HaLinkedEntityService(this.hass);     
+    this.linkedEntityService = new HaLinkedEntityService(this.hass);
     this.urlResolver = new HaUrlResolveService(this.hass, this.linkedEntityService);
-    
+
     L.Icon.Default.imagePath = "/static/images/leaflet/images/";
 
     const mapEl = this.shadowRoot.querySelector('#map');
@@ -159,11 +166,11 @@ export default class MapCard extends LitElement {
     let tileUrl = this.urlResolver.resolveUrl(this._config.tileLayer.url);
     let layer = new TileLayer(tileUrl, this._config.tileLayer.options);
     map.addLayer(layer);
-    this.urlResolver.registerLayer(layer, this._config.tileLayer.url);    
+    this.urlResolver.registerLayer(layer, this._config.tileLayer.url);
     return map;
   }
 
-  
+
 
   setConfig(config) {
     this.config = config;
@@ -213,8 +220,8 @@ export default class MapCard extends LitElement {
     const sampleEntities = Object.keys(hass.states).filter(
       (entityId) => {
         const entity = hass.states[entityId];
-        return (entity.state && entity.attributes && entity.attributes.latitude && entity.attributes.longitude); 
-      }  
+        return (entity.state && entity.attributes && entity.attributes.latitude && entity.attributes.longitude);
+      }
     );
 
     // Sample config

--- a/src/configs/MapConfig.js
+++ b/src/configs/MapConfig.js
@@ -1,4 +1,5 @@
 import EntityConfig from "./EntityConfig.js";
+import PluginConfig from "./PluginConfig.js";
 import TileLayerConfig from "./TileLayerConfig.js";
 import WmsLayerConfig from "./WmsLayerConfig.js";
 import Logger from "../util/Logger.js";
@@ -25,6 +26,8 @@ export default class MapConfig {
   tileLayers;
   /** @type {TileLayerConfig} */
   tileLayer;
+  /** @type {[PluginConfig]} */
+  plugins;
    /** @type {Date|Entity} */
   historyStart;
   /** @type {Date|Entity} */
@@ -92,6 +95,12 @@ export default class MapConfig {
     let tile_layers = this._setConfigWithDefault(inputConfig.tile_layers, []);
     this.tileLayers = (this._setConfigWithDefault(Array.isArray(tile_layers) ? tile_layers : [tile_layers], [])).map((tile) => {
       return new TileLayerConfig(tile.url, tile.options, tile.history);
+    });
+
+    // Allow as none array
+    let plugins = this._setConfigWithDefault(inputConfig.plugins, []);
+    this.plugins = (this._setConfigWithDefault(Array.isArray(plugins) ? plugins : [plugins], [])).map((plugin) => {
+      return new PluginConfig(plugin.url, plugin.name, plugin.options);
     });
 
     this.tileLayer = new TileLayerConfig(

--- a/src/configs/PluginConfig.js
+++ b/src/configs/PluginConfig.js
@@ -1,0 +1,14 @@
+export default class PluginConfig {
+  /** @type {string} */
+  url;
+  /** @type {string} */
+  name;
+  /** @type {object} */
+  options;
+
+  constructor(url, name, options) {
+    this.url = url;
+    this.name = name;
+    this.options = { ...options };
+  }
+}

--- a/src/models/Plugin.js
+++ b/src/models/Plugin.js
@@ -14,7 +14,7 @@ export default class Plugin {
 
   async renderMap() {
     // Mandatory, the method that modifies/updates the leaflet map itself
-    throw new Error(`[HaMapCard] Plugin ${this.name} does not implement a renderMap() method!`, { cause: 'NotImplemented' });
+    throw new Error(`Plugin ${this.name} does not implement a renderMap() method!`, { cause: 'NotImplemented' });
   }
 
   async update() {
@@ -26,6 +26,6 @@ export default class Plugin {
     // Mandatory. Called from PluginsRenderService.cleanup when the
     // MapCard.disconnectedCallback is called. Use this to clean up
     // the state, remove listeners, intervals, timers, etc.
-    throw new Error(`[HaMapCard] Plugin ${this.name} does not implement a destroy() method!`, { cause: 'NotImplemented' });
+    throw new Error(`Plugin ${this.name} does not implement a destroy() method!`, { cause: 'NotImplemented' });
   }
 }

--- a/src/models/Plugin.js
+++ b/src/models/Plugin.js
@@ -1,0 +1,15 @@
+export default class Plugin {
+  constructor(map, name, options = {}) {
+    // TODO error if map and name are undef?
+    this.map = map;
+    this.name = name;
+    this.options = options;
+  }
+
+  init() {
+  }
+
+  render() {
+  }
+
+}

--- a/src/models/Plugin.js
+++ b/src/models/Plugin.js
@@ -1,4 +1,6 @@
 export default class Plugin {
+
+  // can be overwritten if necessary
   constructor(map, name, options = {}) {
     // TODO error if map and name are undef?
     this.map = map;
@@ -6,12 +8,24 @@ export default class Plugin {
     this.options = options;
   }
 
-  init() { }
+  async init() {
+    // Optional, called after the plugin has been constructed
+  }
 
-  // method that modifies the map itself
-  renderMap() { }
+  async renderMap() {
+    // Mandatory, the method that modifies/updates the leaflet map itself
+    throw new Error(`[HaMapCard] Plugin ${this.name} does not implement a renderMap() method!`, { cause: 'NotImplemented' });
+  }
 
-  // used if the plugin needs to respond to state changes
-  update() { }
+  async update() {
+    // Optional, called by the PluginsRenderService.render method
+    // useful if plugin needs to respond to HA state.
+  }
 
+  destroy() {
+    // Mandatory. Called from PluginsRenderService.cleanup when the
+    // MapCard.disconnectedCallback is called. Use this to clean up
+    // the state, remove listeners, intervals, timers, etc.
+    throw new Error(`[HaMapCard] Plugin ${this.name} does not implement a destroy() method!`, { cause: 'NotImplemented' });
+  }
 }

--- a/src/models/Plugin.js
+++ b/src/models/Plugin.js
@@ -6,10 +6,12 @@ export default class Plugin {
     this.options = options;
   }
 
-  init() {
-  }
+  init() { }
 
-  render() {
-  }
+  // method that modifies the map itself
+  renderMap() { }
+
+  // used if the plugin needs to respond to state changes
+  update() { }
 
 }

--- a/src/services/render/PluginsRenderService.js
+++ b/src/services/render/PluginsRenderService.js
@@ -1,0 +1,83 @@
+import Logger from "../../util/Logger.js";
+import PluginConfig from "../../configs/PluginConfig";
+import Plugin from '../../models/Plugin.js'
+import L from "leaflet";
+
+export default class PluginsRenderService {
+  /** @type {L.Map} */
+  map;
+  /** @type {[PluginConfig]} */
+  pluginsConfig;
+  /** @type {Map} */
+  plugins;
+
+  constructor(map, pluginsConfig) {
+    this.map = map;
+    this.pluginsConfig = pluginsConfig;
+    this.plugins = new Map();
+  }
+
+  // Asynchronously load and set up all plugins
+  async setup() {
+    // Load all plugins asynchronously
+    const loadPromises = this.pluginsConfig.map(async (config) => {
+
+      await this.register(config);
+    });
+
+    // Wait for all plugins to finish loading
+    await Promise.all(loadPromises);
+
+
+
+    Logger.debug('All plugins have been loaded and initialized.');
+  }
+
+  async register(config) {
+    try {
+      // Check if the plugin is already registered
+      if (this.plugins.has(config.name)) {
+        Logger.warn(`Plugin ${config.name} is already registered.`);
+        return;
+      }
+
+      // Dynamically import the plugin module from the URL
+      const module = await import(config.url);
+
+      const pluginFactory = module.default;
+
+      // Create a new instance of the plugin with provided options
+      const PluginClass = pluginFactory(L, Plugin);
+      const pluginInstance = new PluginClass(this.map, config.name, config.options)
+
+      // Initialize the plugin if it has an init method
+      if (typeof pluginInstance.init === 'function') {
+        await pluginInstance.init();
+      }
+
+      // Add the loaded plugin instance to the plugins map
+      this.plugins.set(config.name, pluginInstance);
+
+      Logger.debug(`Plugin ${config.name} has been registered and initialized.`);
+      Logger.debug([...this.plugins.keys()]);
+
+      await pluginInstance.render();
+
+    } catch (error) {
+      Logger.error(`Failed to load plugin ${config.name} from ${config.url}:`, error);
+    }
+  }
+
+  async render() {}
+
+  // List all registered plugins
+  listPlugins() {
+    return Array.from(this.plugins.keys());
+  }
+
+  // Get a plugin instance by name
+  getPluginByName(name) {
+    return this.plugins.get(name);
+  }
+
+}

--- a/src/services/render/PluginsRenderService.js
+++ b/src/services/render/PluginsRenderService.js
@@ -27,6 +27,7 @@ export default class PluginsRenderService {
 
     // Wait for all plugins to finish loading
     await Promise.all(loadPromises);
+    Logger.debug(`Initialized plugins: ${[...this.plugins.keys()]}`);
 
 
 
@@ -59,16 +60,22 @@ export default class PluginsRenderService {
       this.plugins.set(config.name, pluginInstance);
 
       Logger.debug(`Plugin ${config.name} has been registered and initialized.`);
-      Logger.debug([...this.plugins.keys()]);
 
-      await pluginInstance.render();
+      await pluginInstance.renderMap();
 
     } catch (error) {
       Logger.error(`Failed to load plugin ${config.name} from ${config.url}:`, error);
     }
   }
 
-  async render() {}
+  async render() {
+    const renderPromises = [];
+    this.plugins.forEach((pluginInstance) => {
+      renderPromises.push(pluginInstance.update());
+    })
+
+    await Promise.all(renderPromises);
+  }
 
   // List all registered plugins
   listPlugins() {

--- a/src/services/render/PluginsRenderService.js
+++ b/src/services/render/PluginsRenderService.js
@@ -27,18 +27,29 @@ export default class PluginsRenderService {
 
     // Wait for all plugins to finish loading
     await Promise.all(loadPromises);
-    Logger.debug(`Initialized plugins: ${[...this.plugins.keys()]}`);
+    Logger.debug(`[PluginsRenderService] Initialized plugins: ${[...this.plugins.keys()]}`);
 
 
 
-    Logger.debug('All plugins have been loaded and initialized.');
+    Logger.debug('[PluginsRenderService] All plugins have been loaded and initialized.');
+  }
+
+  // called by MapCard.disconnectedCallback to deregister plugins
+  cleanup() {
+    this.plugins.forEach((pluginInstance) => {
+      Logger.debug(`[PluginsRenderService] Destroying plugin ${pluginInstance.name}`);
+
+      pluginInstance.destroy();
+    })
+
+    this.plugins.clear();
   }
 
   async register(config) {
     try {
       // Check if the plugin is already registered
       if (this.plugins.has(config.name)) {
-        Logger.warn(`Plugin ${config.name} is already registered.`);
+        Logger.warn(`[PluginsRenderService] Plugin ${config.name} is already registered.`);
         return;
       }
 
@@ -48,10 +59,10 @@ export default class PluginsRenderService {
       const pluginFactory = module.default;
 
       // Create a new instance of the plugin with provided options
-      const PluginClass = pluginFactory(L, Plugin);
+      const PluginClass = pluginFactory(L, Plugin, Logger);
       const pluginInstance = new PluginClass(this.map, config.name, config.options)
 
-      // Initialize the plugin if it has an init method
+      // call the init method of the plugin if it exists
       if (typeof pluginInstance.init === 'function') {
         await pluginInstance.init();
       }
@@ -59,12 +70,12 @@ export default class PluginsRenderService {
       // Add the loaded plugin instance to the plugins map
       this.plugins.set(config.name, pluginInstance);
 
-      Logger.debug(`Plugin ${config.name} has been registered and initialized.`);
+      Logger.debug(`[PluginsRenderService] Plugin ${config.name} has been registered and initialized.`);
 
       await pluginInstance.renderMap();
 
     } catch (error) {
-      Logger.error(`Failed to load plugin ${config.name} from ${config.url}:`, error);
+      Logger.error(`[PluginsRenderService] Failed to load plugin ${config.name} from ${config.url}:`, error);
     }
   }
 


### PR DESCRIPTION
The additions here allow loading of plugins. See `src/CircleTestPlugin.js`  for one such plugin. Having it as a factory function allows a lot of flexibility. I think this implementation is reasonably 'safe' as plugins are given only the map object and the options from the config. Below are some instructions on how to get it working for testing. Documentation and commenting in the classes I've added needs work. I tried to follow your structure @nathan-gs.

# Installation
1. Build and install the map card
2. Copy `src/CircleTestPlugin.js` to the `www` folder.

# Testing
Here is a config for lovelace that will draw two circles on the map.
```yaml
type: custom:map-card
x: -23.698
"y": 133.8807
zoom: 1
debug: true
plugins:
  - name: circle1
    url: /local/CircleTestPlugin.js
    options:
      x: -23.698
      "y": 133.8807
      r: 3000000
      fillColor: green
  - name: circle2
    url: /local/CircleTestPlugin.js
    options:
      x: 20
      "y": 100
      r: 1000000
      fill: false
      color: orange
```
## Result
![circle_plugin](https://github.com/user-attachments/assets/dbdf9d2d-e50e-49b8-961f-3d9620c39f0a)

# Other thoughts
Some of the methods I added are async. I did notice that there are other async methods such as those in `TileLayersRenderService.js` as well. Are these being used correctly if the setup functions in `MapCard.js` aren't themselves async? 

# Backstory
The Aussie Bureau of Meteorology have an undocumented API that serves mapbox vector tiles in their mobile app. I like the BOM radar better than the rainviewer one that I have been using, as it is much higher resolution. I spent some time working on an implementation that can read the vector tiles using `MapLibre GL JS` and plot it on a leaflet map via `maplibre-gl-leaflet`.  Unfortunately, the way they have set up their vector tiles is not exactly 'standard'. It's one of those things that's extremely inefficient and complicated to do if you use homeassistant template sensors and the built-in url templating functionality only, but can be done with only a few lines of code. I think that it makes a decent case for 'plugins' to exist.