### PR TITLE
fix: height in horizontal-stack & grid

### DIFF
--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -105,7 +105,7 @@ export default class MapCard extends LitElement {
 
     return html`
             <link rel="stylesheet" href="/static/images/leaflet/leaflet.css">
-            <ha-card header="${this._config.title}" style="height: 100%">
+            <ha-card header="${this._config.title}">
                 <div id="map" style="min-height: ${this._config.mapHeight}px">
                   <ha-icon-button
                     label='Reset focus'
@@ -226,7 +226,12 @@ export default class MapCard extends LitElement {
   }
 
   static get styles() {
-    return css`       
+    return css`
+      ha-card {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+      }
       #map {
         height: 100%;
         border-radius: var(--ha-card-border-radius,12px);


### PR DESCRIPTION
When a title is set, the card overflows on to a next card (located lower).

For horizontal-stack:
Before:
![image](https://github.com/user-attachments/assets/94eb56e5-259a-4693-8339-60dd6d6be381)

![image](https://github.com/user-attachments/assets/a1910a73-2aa6-47de-b393-08a9c4d0496f)

![image](https://github.com/user-attachments/assets/6f3be47a-6370-4603-bd77-071c0f7571e4)

After:
![image](https://github.com/user-attachments/assets/4775ef32-219d-45e8-b4f7-8699acfa93b0)

![image](https://github.com/user-attachments/assets/173e5693-7079-48e6-8837-6dd242a0ef20)

![image](https://github.com/user-attachments/assets/1b08a715-2b3b-4028-b1da-8f1a145878d3)

For grid - similarly.
Tested with card_size as well.

----------

Test views (card-mod is used to simulate a patched map-card):
```
package_map_card: &ref_map_card
  type: custom:map-card
  entities:
    - device_tracker.virtual_tracker_1

package_map_card_mod: &ref_map_card_mod
  card_mod:
    style: |
      ha-card {
        display: flex;
        flex-direction: column;
      }

package_calendar_card: &ref_calendar_card
  type: calendar
  entities:
    - calendar.calendar_1

package_entity_card: &ref_entity_card
  type: entity
  entity: sun.sun

anchor_log_title: &ref_long_title long long long long
anchor_card_size: &ref_card_size 2

package_markdown_stack: &ref_markdown_stack
  type: markdown
  content: |
    horiz stack
    default size for map-card
    1,2 - default
    3,4 - card-mod for map-card
  card_mod: &ref_card_mod_for_markdown
    style: 'ha-card {color: red;}'

package_markdown_stack_custom_size: &ref_markdown_stack_custom_size
  type: markdown
  content: |
    horiz stack
    custom size for map-card
    1,2 - default
    3,4 - card-mod for map-card
  card_mod: *ref_card_mod_for_markdown

#######################################################################################################

title: "ha-map-card: height in stack"
path: ha-map-card-height-stack
subview: true
type: custom:vertical-layout
cards:

  - *ref_markdown_stack

  - type: horizontal-stack
    cards:
      - *ref_map_card
      - *ref_calendar_card

  - type: horizontal-stack
    cards:
      - <<: *ref_map_card
        title: *ref_long_title
      - *ref_calendar_card

  - type: horizontal-stack
    cards:
      - <<: *ref_map_card
        <<: *ref_map_card_mod
      - *ref_calendar_card

  - type: horizontal-stack
    cards:
      - <<: *ref_map_card
        title: *ref_long_title
        <<: *ref_map_card_mod
      - *ref_calendar_card

  #############################################################################################
  - type: custom:layout-break

  - *ref_markdown_stack

  - type: horizontal-stack
    cards:
      - *ref_map_card
      - *ref_entity_card

  - type: horizontal-stack
    cards:
      - <<: *ref_map_card
        title: *ref_long_title
      - *ref_entity_card

  - type: horizontal-stack
    cards:
      - <<: *ref_map_card
        <<: *ref_map_card_mod
      - *ref_entity_card

  - type: horizontal-stack
    cards:
      - <<: *ref_map_card
        title: *ref_long_title
        <<: *ref_map_card_mod
      - *ref_entity_card

  #############################################################################################
  - type: custom:layout-break

  - *ref_markdown_stack_custom_size

  - type: horizontal-stack
    cards:
      - <<: *ref_map_card
        card_size: *ref_card_size
      - *ref_calendar_card

  - type: horizontal-stack
    cards:
      - <<: *ref_map_card
        title: *ref_long_title
        card_size: *ref_card_size
      - *ref_calendar_card

  - type: horizontal-stack
    cards:
      - <<: *ref_map_card
        <<: *ref_map_card_mod
        card_size: *ref_card_size
      - *ref_calendar_card

  - type: horizontal-stack
    cards:
      - <<: *ref_map_card
        title: *ref_long_title
        <<: *ref_map_card_mod
        card_size: *ref_card_size
      - *ref_calendar_card

  #############################################################################################
  - type: custom:layout-break

  - *ref_markdown_stack_custom_size

  - type: horizontal-stack
    cards:
      - <<: *ref_map_card
        card_size: *ref_card_size
      - *ref_entity_card

  - type: horizontal-stack
    cards:
      - <<: *ref_map_card
        title: *ref_long_title
        card_size: *ref_card_size
      - *ref_entity_card

  - type: horizontal-stack
    cards:
      - <<: *ref_map_card
        <<: *ref_map_card_mod
        card_size: *ref_card_size
      - *ref_entity_card

  - type: horizontal-stack
    cards:
      - <<: *ref_map_card
        title: *ref_long_title
        <<: *ref_map_card_mod
        card_size: *ref_card_size
      - *ref_entity_card
```
```
package_map_card: &ref_map_card
  type: custom:map-card
  entities:
    - device_tracker.virtual_tracker_1

package_map_card_mod: &ref_map_card_mod
  card_mod:
    style: |
      ha-card {
        display: flex;
        flex-direction: column;
      }

package_calendar_card: &ref_calendar_card
  type: calendar
  entities:
    - calendar.calendar_1

package_entity_card: &ref_entity_card
  type: entity
  entity: sun.sun

anchor_log_title: &ref_long_title long long long long
anchor_card_size: &ref_card_size 2

package_markdown_grid: &ref_markdown_grid
  type: markdown
  content: |
    grid
    default size for map-card
    1,2 - default
    3,4 - card-mod for map-card
  card_mod: &ref_card_mod_for_markdown
    style: 'ha-card {color: red;}'

package_markdown_grid_custom_size: &ref_markdown_grid_custom_size
  type: markdown
  content: |
    grid
    custom size for map-card
    1,2 - default
    3,4 - card-mod for map-card
  card_mod: *ref_card_mod_for_markdown

anchor_grid_settings: &ref_grid_settings
  columns: 2
  square: false

#######################################################################################################

title: "ha-map-card: height in grid"
path: ha-map-card-height-grid
subview: true
type: custom:vertical-layout
cards:

  - *ref_markdown_grid

  - type: grid
    <<: *ref_grid_settings
    cards:
      - *ref_map_card
      - *ref_calendar_card

  - type: grid
    <<: *ref_grid_settings
    cards:
      - <<: *ref_map_card
        title: *ref_long_title
      - *ref_calendar_card

  - type: grid
    <<: *ref_grid_settings
    cards:
      - <<: *ref_map_card
        <<: *ref_map_card_mod
      - *ref_calendar_card

  - type: grid
    <<: *ref_grid_settings
    cards:
      - <<: *ref_map_card
        title: *ref_long_title
        <<: *ref_map_card_mod
      - *ref_calendar_card

  #############################################################################################
  - type: custom:layout-break

  - *ref_markdown_grid

  - type: grid
    <<: *ref_grid_settings
    cards:
      - *ref_map_card
      - *ref_entity_card

  - type: grid
    <<: *ref_grid_settings
    cards:
      - <<: *ref_map_card
        title: *ref_long_title
      - *ref_entity_card

  - type: grid
    <<: *ref_grid_settings
    cards:
      - <<: *ref_map_card
        <<: *ref_map_card_mod
      - *ref_entity_card

  - type: grid
    <<: *ref_grid_settings
    cards:
      - <<: *ref_map_card
        title: *ref_long_title
        <<: *ref_map_card_mod
      - *ref_entity_card

  #############################################################################################
  - type: custom:layout-break

  - *ref_markdown_grid_custom_size

  - type: grid
    <<: *ref_grid_settings
    cards:
      - <<: *ref_map_card
        card_size: *ref_card_size
      - *ref_calendar_card

  - type: grid
    <<: *ref_grid_settings
    cards:
      - <<: *ref_map_card
        title: *ref_long_title
        card_size: *ref_card_size
      - *ref_calendar_card

  - type: grid
    <<: *ref_grid_settings
    cards:
      - <<: *ref_map_card
        <<: *ref_map_card_mod
        card_size: *ref_card_size
      - *ref_calendar_card

  - type: grid
    <<: *ref_grid_settings
    cards:
      - <<: *ref_map_card
        title: *ref_long_title
        <<: *ref_map_card_mod
        card_size: *ref_card_size
      - *ref_calendar_card

  #############################################################################################
  - type: custom:layout-break

  - *ref_markdown_grid_custom_size

  - type: grid
    <<: *ref_grid_settings
    cards:
      - <<: *ref_map_card
        card_size: *ref_card_size
      - *ref_entity_card

  - type: grid
    <<: *ref_grid_settings
    cards:
      - <<: *ref_map_card
        title: *ref_long_title
        card_size: *ref_card_size
      - *ref_entity_card

  - type: grid
    <<: *ref_grid_settings
    cards:
      - <<: *ref_map_card
        <<: *ref_map_card_mod
        card_size: *ref_card_size
      - *ref_entity_card

  - type: grid
    <<: *ref_grid_settings
    cards:
      - <<: *ref_map_card
        title: *ref_long_title
        <<: *ref_map_card_mod
        card_size: *ref_card_size
      - *ref_entity_card
```