### PR TITLE
Reload entity state & lat/long from Hass websocket subscription + Follow Date Range managers

### DIFF
--- a/src/models/Circle.js
+++ b/src/models/Circle.js
@@ -21,7 +21,7 @@ export default class Circle {
     if(this.config.source == "config") {
       return this.config.radius ?? 0;
     }
-    const attributes = this.entity.state.attributes;
+    const attributes = this.entity.attributes;
     if(this.config.source == "attribute") {
       return attributes[this.config.attribute] ?? 0;
     }
@@ -42,7 +42,7 @@ export default class Circle {
       if(this.config.source == "config") {
         Logger.debug(`[Circle]: for ${this.entity.id}, using config, resulting in: ${this.config.radius}`);
       }
-      const attributes = this.entity.state.attributes;
+      const attributes = this.entity.attributes;
       if(this.config.source == "attribute") {
         Logger.debug(`[Circle]: for ${this.entity.id}, using attribute (${this.config.attribute}), resulting in: ${attributes[this.config.attribute]}`);
       }

--- a/src/models/Circle.test.js
+++ b/src/models/Circle.test.js
@@ -25,11 +25,10 @@ describe('Circle', () => {
     entity = {
       id: 'test-entity',
       latLng: [0, 0],
-      state: {
-        attributes: {
-          gps_accuracy: 50,
-          radius: 200,
-        }
+
+      attributes: {
+        gps_accuracy: 50,
+        radius: 200,
       },
       config: {
         id: 'test-entity',
@@ -65,19 +64,19 @@ describe('Circle', () => {
     });
 
     it('should return radius from attributes when source is auto and no gps_accuracy', () => {
-      entity.state.attributes = { radius: 200 };
+      entity.attributes = { radius: 200 };
       circle.config.source = "attribute";
       circle.config.attribute = "radius";
       expect(circle.radius).toBe(200);
     });
 
     it('should return config radius if no other source applies', () => {
-      entity.state.attributes = {};
+      entity.attributes = {};
       expect(circle.radius).toBe(100);
     });
 
     it('should return 0 if nothing else applies', () => {
-      entity.state.attributes = {};
+      entity.attributes = {};
       circle.config.radius = 0;
       expect(circle.radius).toBe(0);
     });
@@ -86,11 +85,11 @@ describe('Circle', () => {
 
   describe('update method', () => {
     it('should update the circle\'s position and radius if it exists', () => {
-      circle.entity.state.attributes = { radius: 0 };
+      circle.entity.attributes = { radius: 0 };
       circle.config.source = "attribute";
       circle.config.attribute = "radius";
       circle.setup(); // Ensure circle exists      
-      circle.entity.state.attributes = { radius: 50 };
+      circle.entity.attributes = { radius: 50 };
       circle.update();
       expect(circle.circle.getRadius()).toBe(50);
     });

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -1,5 +1,5 @@
 
-import L, { LatLng, Map } from "leaflet";
+import { DivIcon, LatLng, Map, Marker } from "leaflet";
 import Circle from "./Circle.js";
 import Logger from "../util/Logger.js"
 import EntityConfig from "../configs/EntityConfig.js";
@@ -9,23 +9,50 @@ import TimelineEntry from "./TimelineEntry.js";
 export default class Entity {
   /** @type {EntityConfig} */
   config;
-  /** @private @type {L.Marker} */
+  /** 
+   * @private 
+   * @type {Marker} 
+   */
   marker;
-  /** @private @type {object} */
+  /** 
+   * @private 
+   * @type {object} 
+   */
   hass;
-  /** @private @type {Map} */
+  /** 
+   * @private 
+   * @type {Map}
+   */
   map;
-  /** @private @type {string} */
+  /**
+   * @private 
+   * @type {string} 
+   */
   _currentTitle;
-  /** @private @type {[boolean]} */
+  /** 
+   * @private
+   * @type {boolean} 
+   */
   darkMode;
-  /** @private @type {Circle} */
+  /** 
+   * @private
+   * @type {Circle} 
+   */
   circle;
-  /** @private @type {EntityHistoryManager} */
+  /** 
+   * @private 
+   * @type {EntityHistoryManager} 
+   */
   historyManager;
-  /** @private @type {TimelineEntry} */
+  /** 
+   * @private 
+   * @type {TimelineEntry} 
+   */
   currentTimelineEntry;
-  /** @private @type {LatLng} */
+  /** 
+   * @private
+   * @type {LatLng} 
+   */
   _currentLatLng;  
 
   constructor(config, hass, map, historyService, dateRangeManager, linkedEntityService, darkMode) {
@@ -56,12 +83,15 @@ export default class Entity {
     return this.hass.formatEntityState(this.hass.states[this.id], this.currentTimelineEntry?.state.s) ?? this.hass.formatEntityState(this.hass.states[this.id]);
   }
 
-  /** @returns {Object.<string, *} */
+  /** @returns {{[key: string]: object}} */
   get attributes() {
     return this.currentTimelineEntry?.state.a ?? this.hass.states[this.id].attributes;
   }
 
-  /** @private @returns {string} */
+  /** 
+   * @private 
+   * @returns {string}
+   */
   get picture() {
     // If no configured picture, fallback to entity picture
     let picture = this.config.picture ?? this.attributes.entity_picture;
@@ -70,13 +100,13 @@ export default class Entity {
   }
 
   /** @returns {LatLng} */
-  get latLng() {
-    if(this._currentLatLng) {
-      return this._currentLatLng;
-    }
-
+  get latLng() {    
     if(this.config.fixedX && this.config.fixedY) {
       return new LatLng(this.config.fixedX, this.config.fixedY);
+    }
+    
+    if(this._currentLatLng) {
+      return this._currentLatLng;
     }
     
     // Do we have Lng/Lat directly?
@@ -165,7 +195,10 @@ export default class Entity {
     this.circle.update();
   }
 
-  /** @private */
+  /**
+   * @private 
+   * @returns {Marker}
+   */
   createMapMarker() {
     Logger.debug("[MarkerEntity] Creating marker for " + this.id + " with display mode " + this.display);
     let icon = this.icon;
@@ -180,8 +213,8 @@ export default class Entity {
 
     const extraCssClasses = this.darkMode ? "dark" : "";
 
-    return L.marker(this.latLng, {
-      icon: L.divIcon({
+    return new Marker(this.latLng, {
+      icon: new DivIcon({
         html: `
           <map-card-entity-marker
             entity-id="${this.id}"

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -4,24 +4,31 @@ import Circle from "./Circle.js";
 import Logger from "../util/Logger.js"
 import EntityConfig from "../configs/EntityConfig.js";
 import EntityHistoryManager from "./EntityHistoryManager.js";
+import TimelineEntry from "./TimelineEntry.js";
 
 export default class Entity {
   /** @type {EntityConfig} */
   config;
-  /** @type {L.Marker} */
+  /** @private @type {L.Marker} */
   marker;
-  /** @type {object} */
+  /** @private @type {object} */
   hass;
-  /** @type {Map} */
+  /** @private @type {Map} */
   map;
-  /** @type {string} */
+  /** @private @type {string} */
   _currentTitle;
-  /** @type {[boolean]} */
+  /** @private @type {[boolean]} */
   darkMode;
-  /** @type {Circle} */
+  /** @private @type {Circle} */
   circle;
-  /** @type {EntityHistoryManager} */
+  /** @private @type {EntityHistoryManager} */
   historyManager;
+  /** @private @type {TimelineEntry} */
+  currentTimelineEntry;
+  /** @private @type {LatLng} */
+  _currentLatLng;  
+  /** @private @type {boolean} */
+  _resetReactive = false;
 
   constructor(config, hass, map, historyService, dateRangeManager, linkedEntityService, darkMode) {
     this.config = config;
@@ -46,32 +53,42 @@ export default class Entity {
 
   /** @returns {object} */
   get state() {
-    return this.hass.states[this.id];
+    return this.currentTimelineEntry?.state.s ?? this.hass.states[this.id];
   }
 
+  /** @returns {Object.<string, *} */
+  get attributes() {
+    return this.currentTimelineEntry?.state.a ?? this.hass.states[this.id].attributes;
+  }
+
+  /** @private @returns {string} */
   get picture() {
     // If no configured picture, fallback to entity picture
-    let picture = this.config.picture ?? this.state.attributes.entity_picture;
+    let picture = this.config.picture ?? this.attributes.entity_picture;
     // Skip if neither found and return null
     return picture ? this.hass.hassUrl(picture) : null;
   }
 
   /** @returns {LatLng} */
   get latLng() {
+    if(this._currentLatLng) {
+      return this._currentLatLng;
+    }
+
     if(this.config.fixedX && this.config.fixedY) {
       return new LatLng(this.config.fixedX, this.config.fixedY);
     }
     
     // Do we have Lng/Lat directly?
-    if (this.state.attributes.latitude && this.state.attributes.longitude) {
-      return new LatLng(this.state.attributes.latitude, this.state.attributes.longitude);
+    if (this.attributes.latitude && this.attributes.longitude) {
+      return new LatLng(this.attributes.latitude, this.attributes.longitude);
     }
     
     // Get Lat/Lng of entity. Some entities such as "person" define device_trackers allowing
     // multiple lat/lng sources to be used. This method will call down through these looking for a
     // lat/lng value if none is defined on the parent entity.
     // If any, see if we can get a lng/lat from one instead
-    let subTrackerIds = this.state?.attributes?.device_trackers ?? []
+    let subTrackerIds = this.attributes.device_trackers ?? []
     for(let t=0; t<subTrackerIds.length; t++) {
       const entity = this.hass.states[subTrackerIds[t]];
       if (entity.attributes.latitude && entity.attributes.longitude) {
@@ -88,14 +105,41 @@ export default class Entity {
   }
 
   setup() {
-    this.marker = this._createMapMarker();
+    this.marker = this.createMapMarker();
     this.marker.addTo(this.map);
     this.historyManager.setup();
     this.circle.setup();
   }
 
+  /** @param {TimelineEntry} entry */  
+  react(entry) {
+    const updateEntity = (entry) => {
+      Logger.debug("[Entity] Date Reset, reacting to new entry for " + entry.entityId);
+      if (entry.entityId == this.id) {
+        this._resetReactive = false;
+        this.currentTimelineEntry = entry;
+      }
+      this._currentLatLng = new LatLng(entry.latitude, entry.longitude);
+      this.update()
+    }
+
+    if(this._resetReactive) {
+      updateEntity(entry)
+    }
+    if(this.currentTimelineEntry) {
+      if(entry.timestamp > this.currentTimelineEntry.timestamp) {
+        updateEntity(entry)
+      }
+    }
+  }
+
+  resetReactive() {
+    Logger.debug(`[Entity]: resetting reactive`);
+    this._resetReactive = true;
+  }
+
   get friendlyName() {
-    return this.state.attributes?.friendly_name ?? this.id;
+    return this.attributes.friendly_name ?? this.id;
   }
 
   /** @returns {string} */
@@ -122,11 +166,7 @@ export default class Entity {
   }
 
   get icon() {
-    return this.config.icon ?? this.state.attributes.icon;
-  }
-
-  _markerCss(size) {
-    return `style="height: ${size}px; width: ${size}px;"`;
+    return this.config.icon ?? this.attributes.icon;
   }
 
   async update() {
@@ -134,7 +174,7 @@ export default class Entity {
       if(this.title != this._currentTitle) {
         Logger.debug("[Entity] updating marker for " + this.id + " from " + this._currentTitle + " to " + this.state);
         this.marker.remove();
-        this.marker = this._createMapMarker();
+        this.marker = this.createMapMarker();
         this.marker.addTo(this.map);
         this._currentTitle = this.title;
       }
@@ -144,7 +184,8 @@ export default class Entity {
     this.circle.update();
   }
 
-  _createMapMarker() {
+  /** @private */
+  createMapMarker() {
     Logger.debug("[MarkerEntity] Creating marker for " + this.id + " with display mode " + this.display);
     let icon = this.icon;
     let picture = this.picture;

--- a/src/models/EntityHistory.js
+++ b/src/models/EntityHistory.js
@@ -38,7 +38,7 @@ export default class EntityHistory {
   /**
    * @returns {[(Polyline|CircleMarker)]} 
    */
-  render() {
+  update() {
     if(this.needRerender == false || this.entries.length == 0) {
       return [];
     }

--- a/src/models/EntityHistory.js
+++ b/src/models/EntityHistory.js
@@ -29,7 +29,8 @@ export default class EntityHistory {
     this.showLines = showLines;
   }
 
-  retrieve = (entry) => {
+  /** @param {TimelineEntry} entry  */
+  react(entry) {
     this.entries.push(entry);
     this.needRerender = true;
   };

--- a/src/models/EntityHistory.js
+++ b/src/models/EntityHistory.js
@@ -49,8 +49,13 @@ export default class EntityHistory {
     let baseOpacity;
 
     if (this.gradualOpacity) {
-      opacityStep = this.gradualOpacity / (this.entries.length - 2);
-      baseOpacity = 1 - this.gradualOpacity;
+      if(this.entries.length <= 2) {
+        baseOpacity = 1;
+        opacityStep = 0;
+      } else {
+        opacityStep = this.gradualOpacity / (this.entries.length - 2);
+        baseOpacity = 1 - this.gradualOpacity;
+      }
     }
 
     for (let i = 0; i < this.entries.length - 1; i++) {

--- a/src/models/EntityHistory.test.js
+++ b/src/models/EntityHistory.test.js
@@ -1,0 +1,159 @@
+import EntityHistory from './EntityHistory';
+import L from 'leaflet';
+import TimelineEntry from './TimelineEntry';
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+
+describe('EntityHistory', () => {
+  let entityHistory;
+
+  beforeEach(() => {
+    entityHistory = new EntityHistory(
+      'entity-1',
+      'Test Entity',
+      'red',
+      0.5,
+      true,  // showDots
+      true   // showLines
+    );
+  });
+
+  describe('constructor', () => {
+    it('should initialize with provided parameters', () => {
+      expect(entityHistory.entityId).toBe('entity-1');
+      expect(entityHistory.entityTitle).toBe('Test Entity');
+      expect(entityHistory.color).toBe('red');
+      expect(entityHistory.gradualOpacity).toBe(0.5);
+      expect(entityHistory.showDots).toBe(true);
+      expect(entityHistory.showLines).toBe(true);
+    });
+  });
+
+  describe('react', () => {
+    it('should add new TimelineEntry to entries array and set needRerender to true', () => {
+      const mockEntry = new TimelineEntry(new Date(), "original-entity", "entity", { a: {latitude: 51.5, longitude: -0.1} });
+      entityHistory.react(mockEntry);
+      expect(entityHistory.entries).toHaveLength(1);
+      expect(entityHistory.entries[0]).toBe(mockEntry);
+      expect(entityHistory.needRerender).toBe(true);
+    });
+  });
+
+  describe('update', () => {
+    it('should return an empty array if no entries or no rerender needed', () => {
+      expect(entityHistory.update()).toEqual([]);
+    });
+
+    it('should create CircleMarkers for each entry when showDots is true', () => {
+      const mockEntry1 = new TimelineEntry(new Date(), "original-entity", "entity", { a: {latitude: 51.5, longitude: -0.1} });
+      const mockEntry2 = new TimelineEntry(new Date(), "original-entity", "entity", { a: {latitude: 51.6, longitude: -0.2} });
+      const mockEntry3 = new TimelineEntry(new Date(), "original-entity", "entity", { a: {latitude: 51.7, longitude: -0.3} });
+      
+      entityHistory.react(mockEntry1);
+      entityHistory.react(mockEntry2);
+      entityHistory.react(mockEntry3);
+
+      const spyCircleMarker = jest.spyOn(L, 'circleMarker').mockImplementation(() => ({
+        bindTooltip: jest.fn(),
+        remove: jest.fn()
+      }));
+
+      const result = entityHistory.update();
+
+      expect(result).toHaveLength(4);
+      expect(spyCircleMarker).toHaveBeenCalledTimes(2);
+      expect(spyCircleMarker).toHaveBeenCalledWith([51.5, -0.1], expect.objectContaining({
+        radius: 3,
+        color: 'red',
+        opacity: 0.5,
+        fillOpacity: 0.5,
+        interactive: true
+      }));
+
+      spyCircleMarker.mockRestore();
+    });
+
+    it('should create CircleMarkers for each entry when showDots is true, if only 2 entries, show no gradual opacity', () => {
+      const mockEntry1 = new TimelineEntry(new Date(), "original-entity", "entity", { a: {latitude: 51.5, longitude: -0.1} });
+      const mockEntry2 = new TimelineEntry(new Date(), "original-entity", "entity", { a: {latitude: 51.6, longitude: -0.2} });
+      
+      entityHistory.react(mockEntry1);
+      entityHistory.react(mockEntry2);
+
+      const spyCircleMarker = jest.spyOn(L, 'circleMarker').mockImplementation(() => ({
+        bindTooltip: jest.fn(),
+        remove: jest.fn()
+      }));
+
+      const result = entityHistory.update();
+
+      expect(result).toHaveLength(2);
+      expect(spyCircleMarker).toHaveBeenCalledTimes(1);
+      expect(spyCircleMarker).toHaveBeenCalledWith([51.5, -0.1], expect.objectContaining({
+        radius: 3,
+        color: 'red',
+        opacity: 1,
+        fillOpacity: 1,
+        interactive: true
+      }));
+
+      spyCircleMarker.mockRestore();
+    });
+
+    it('should create Polylines between entries when showLines is true', () => {
+      const mockEntry1 = new TimelineEntry(new Date(), "original-entity", "entity", { a: {latitude: 51.5, longitude: -0.1} });
+      const mockEntry2 = new TimelineEntry(new Date(), "original-entity", "entity", { a: {latitude: 51.6, longitude: -0.2} });
+      const mockEntry3 = new TimelineEntry(new Date(), "original-entity", "entity", { a: {latitude: 51.6, longitude: -0.2} });
+      
+      entityHistory.react(mockEntry1);
+      entityHistory.react(mockEntry2);
+      entityHistory.react(mockEntry3);
+
+      const spyPolyline = jest.spyOn(L, 'polyline').mockImplementation(() => ({
+        remove: jest.fn()
+      }));
+
+      const result = entityHistory.update();
+
+      expect(result).toHaveLength(4); // Assuming both dots and lines are shown
+      expect(spyPolyline).toHaveBeenCalledTimes(2);
+      expect(spyPolyline).toHaveBeenCalledWith([ [51.5, -0.1], [51.6, -0.2] ], expect.objectContaining({
+        color: 'red',
+        opacity: 0.5,
+        interactive: false
+      }));
+
+      spyPolyline.mockRestore();
+    });
+
+    it('should create Polylines between entries when showLines is true, if only 2 entries, show no gradual opacity', () => {
+      const mockEntry1 = new TimelineEntry(new Date(), "original-entity", "entity", { a: {latitude: 51.5, longitude: -0.1} });
+      const mockEntry2 = new TimelineEntry(new Date(), "original-entity", "entity", { a: {latitude: 51.6, longitude: -0.2} });
+
+      entityHistory.react(mockEntry1);
+      entityHistory.react(mockEntry2);
+
+      const spyPolyline = jest.spyOn(L, 'polyline').mockImplementation(() => ({
+        remove: jest.fn()
+      }));
+
+      const result = entityHistory.update();
+
+      expect(result).toHaveLength(2); // Assuming both dots and lines are shown
+      expect(spyPolyline).toHaveBeenCalledTimes(1);
+      expect(spyPolyline).toHaveBeenCalledWith([ [51.5, -0.1], [51.6, -0.2] ], expect.objectContaining({
+        color: 'red',
+        opacity: 1,
+        interactive: false
+      }));
+
+      spyPolyline.mockRestore();
+    });
+
+    it('should set needRerender to false after update', () => {
+      const mockEntry = new TimelineEntry(new Date(), "original-entity", "entity", { a: {latitude: 51.5, longitude: -0.1} });
+      entityHistory.react(mockEntry);
+      entityHistory.update();
+      expect(entityHistory.needRerender).toBe(false);
+    });
+  });
+});

--- a/src/models/EntityHistoryManager.js
+++ b/src/models/EntityHistoryManager.js
@@ -44,7 +44,7 @@ export default class EntityHistoryManager {
       this.historyLayerGroup = new LayerGroup();
       this.entity.map.addLayer(this.historyLayerGroup);         
 
-      this.history?.render().flat().forEach((marker) => {
+      this.history?.update().flat().forEach((marker) => {
         marker.addTo(this.historyLayerGroup);
       });
     }
@@ -97,7 +97,6 @@ export default class EntityHistoryManager {
   setHistoryDates(start, end) {
     this.currentHistoryStart = start;
     this.currentHistoryEnd = end;
-    this.entity.resetReactive();
   }
 
   refreshHistory() {
@@ -115,6 +114,10 @@ export default class EntityHistoryManager {
 
   /** @param {TimelineEntry} entry */
   react = (entry) => {
+    if(entry.originalEntityId != this.entity.id) {
+      return;
+    }
+
     if(this.hasHistory) {
       this.history.react(entry);
     }
@@ -127,7 +130,7 @@ export default class EntityHistoryManager {
     if(!this.hasHistory) {
       return;
     }
-    this.history?.render().flat().forEach((marker) => {
+    this.history?.update().flat().forEach((marker) => {
       marker.addTo(this.historyLayerGroup);
     });
   }

--- a/src/models/EntityHistoryManager.js
+++ b/src/models/EntityHistoryManager.js
@@ -109,7 +109,7 @@ export default class EntityHistoryManager {
     if(this.hasHistory) {
       this.history = new EntityHistory(this.entity.id, this.entity.tooltip, this.entity.config.historyLineColor, this.entity.config.gradualOpacity, this.entity.config.historyShowDots, this.entity.config.historyShowLines);
     }
-    this.historyService.subscribe(this.entity.id, start, end, this.react, this.entity.config.useBaseEntityOnly);
+    this.historyService.subscribe(this.entity.id, start, end, this.react.bind(this), this.entity.config.useBaseEntityOnly);
   }
 
   /** @param {TimelineEntry} entry */

--- a/src/models/EntityHistoryManager.js
+++ b/src/models/EntityHistoryManager.js
@@ -6,6 +6,7 @@ import HaDateRangeService from '../services/HaDateRangeService';
 import HaLinkedEntityService from '../services/HaLinkedEntityService';
 import Entity from './Entity';
 import Logger from '../util/Logger';
+import TimelineEntry from './TimelineEntry';
 
 export default class EntityHistoryManager {
   /** @type {Entity} */
@@ -37,14 +38,19 @@ export default class EntityHistoryManager {
   }
 
   setup() {
+    this.setupListeners();
+
     if (this.hasHistory) {
       this.historyLayerGroup = new LayerGroup();
-      this.entity.map.addLayer(this.historyLayerGroup);    
-      this._setupHistoryListeners();
+      this.entity.map.addLayer(this.historyLayerGroup);         
+
+      this.history?.render().flat().forEach((marker) => {
+        marker.addTo(this.historyLayerGroup);
+      });
     }
   }
 
-  _setupHistoryListeners() {
+  setupListeners() {
     if (this.entity.config.usingDateRangeManager) {
       Logger.debug(`[EntityHistoryManager] Using date range manager for ${this.entity.id}`);
       this.dateRangeManager.onDateRangeChange((range) => {
@@ -83,26 +89,39 @@ export default class EntityHistoryManager {
       this.currentHistoryEnd = this.entity.config.historyEnd;
     }
 
-    if (this.entity.config.historyStart && !this.entity.config.historyEndEntity) {
-      this._subscribeHistory(this.entity.config.historyStart, this.entity.config.historyEnd);
-    }
+    const historyStart = this.entity.config.historyStart ?? new Date(Date.now() - 10 * 1000);
+    this.subscribeHistory(historyStart, this.entity.config.historyEnd);    
+
   }
 
   setHistoryDates(start, end) {
     this.currentHistoryStart = start;
     this.currentHistoryEnd = end;
+    this.entity.resetReactive();
   }
 
   refreshHistory() {
     Logger.debug(`[EntityHistoryManager] Refreshing history for ${this.entity.id}: ${this.currentHistoryStart} -> ${this.currentHistoryEnd}`);
     this.historyLayerGroup.clearLayers();
-    this._subscribeHistory(this.currentHistoryStart, this.currentHistoryEnd);
+    this.subscribeHistory(this.currentHistoryStart, this.currentHistoryEnd);
   }
 
-  _subscribeHistory(start, end) {
-    this.history = new EntityHistory(this.entity.id, this.entity.tooltip, this.entity.config.historyLineColor, this.entity.config.gradualOpacity, this.entity.config.historyShowDots, this.entity.config.historyShowLines);
-    this.historyService.subscribe(this.history.entityId, start, end, this.history.retrieve, this.entity.config.useBaseEntityOnly);
+  subscribeHistory(start, end) {
+    if(this.hasHistory) {
+      this.history = new EntityHistory(this.entity.id, this.entity.tooltip, this.entity.config.historyLineColor, this.entity.config.gradualOpacity, this.entity.config.historyShowDots, this.entity.config.historyShowLines);
+    }
+    this.historyService.subscribe(this.entity.id, start, end, this.react, this.entity.config.useBaseEntityOnly);
   }
+
+  /** @param {TimelineEntry} entry */
+  react = (entry) => {
+    if(this.hasHistory) {
+      this.history.react(entry);
+    }
+    this.entity.react(entry);
+  }
+
+  
 
   update() {
     if(!this.hasHistory) {

--- a/src/models/EntityHistoryManager.test.js
+++ b/src/models/EntityHistoryManager.test.js
@@ -1,0 +1,103 @@
+import EntityHistoryManager from './EntityHistoryManager';
+import { LayerGroup } from 'leaflet';
+import Entity from './Entity';
+import HaHistoryService from '../services/HaHistoryService';
+import HaDateRangeService from '../services/HaDateRangeService';
+import HaLinkedEntityService from '../services/HaLinkedEntityService';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+jest.mock('../util/Logger');
+jest.mock('../util/HaMapUtilities');
+jest.mock('../services/HaHistoryService');
+jest.mock('../services/HaDateRangeService');
+jest.mock('../services/HaLinkedEntityService');
+
+describe('EntityHistoryManager', () => {
+  let entityHistoryManager;
+  let entity;
+
+  beforeEach(() => {
+    const entityConfig = { id: 'testEntity', hasHistory: true, usingDateRangeManager: true, historyStart: new Date(), historyEnd: new Date(), historyLineColor: 'blue', gradualOpacity: 0.5, historyShowDots: true, historyShowLines: true }
+    const map = { addLayer: jest.fn() };
+    const hass = { states: { 'testEntity': { attributes: { friendly_name: 'Test Entity' } } } };
+    const mockHistoryService = new HaHistoryService();
+    const mockDateRangeManager = new HaDateRangeService();
+    const mockLinkedEntityService = new HaLinkedEntityService();
+    entity = new Entity(entityConfig, hass, map, mockHistoryService, mockDateRangeManager, mockLinkedEntityService, true);
+    
+    entityHistoryManager = new EntityHistoryManager(entity, mockHistoryService, mockDateRangeManager, mockLinkedEntityService);
+    entityHistoryManager.historyLayerGroup = new LayerGroup();
+  });
+
+  describe('hasHistory getter', () => {
+    it('should return the hasHistory config of the entity', () => {
+      expect(entityHistoryManager.hasHistory).toBe(true);
+    });
+  });
+
+  describe('setup', () => {
+    it('should initialize historyLayerGroup and setup listeners if hasHistory is true', () => {
+      const spyAddLayer = jest.spyOn(entity.map, 'addLayer');
+      entityHistoryManager.setup();
+      expect(spyAddLayer).toHaveBeenCalledWith(entityHistoryManager.historyLayerGroup);
+      spyAddLayer.mockRestore();
+    });
+  });
+
+  describe('setupListeners', () => {
+
+    it('should setup listeners for LinkedEntityService for history start and end dates', () => {
+      const mockOnStateChange = jest.fn();
+      entityHistoryManager.linkedEntityService.onStateChange = mockOnStateChange;
+
+      entityHistoryManager.entity.config.historyStartEntity = 'startEntity';
+      entityHistoryManager.entity.config.historyEndEntity = 'endEntity';
+      entityHistoryManager.setupListeners();
+      
+      expect(mockOnStateChange).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('setHistoryDates', () => {
+    it('should update currentHistoryStart and currentHistoryEnd', () => {
+      const start = new Date('2023-01-01');
+      const end = new Date('2023-12-31');
+      entityHistoryManager.setHistoryDates(start, end);
+      expect(entityHistoryManager.currentHistoryStart).toEqual(start);
+      expect(entityHistoryManager.currentHistoryEnd).toEqual(end);
+    });
+  });
+
+  describe('refreshHistory', () => {
+    it('should clear layers and subscribe to history', () => {
+      const spyClearLayers = jest.spyOn(entityHistoryManager.historyLayerGroup, 'clearLayers');
+      const spySubscribe = jest.spyOn(entityHistoryManager.historyService, 'subscribe');
+      
+      entityHistoryManager.refreshHistory();
+      
+      expect(spyClearLayers).toHaveBeenCalled();
+      expect(spySubscribe).toHaveBeenCalled();
+      
+      spyClearLayers.mockRestore();
+      spySubscribe.mockRestore();
+    });
+  });
+
+  describe('subscribeHistory', () => {
+    it('should create new EntityHistory and call subscribe on historyService', () => {
+      const spySubscribe = jest.spyOn(entityHistoryManager.historyService, 'subscribe');
+      entityHistoryManager.subscribeHistory(new Date(), new Date());
+      expect(spySubscribe).toHaveBeenCalledWith(entity.id, expect.any(Date), expect.any(Date), expect.any(Function), undefined);
+      spySubscribe.mockRestore();
+    });
+  });
+
+  describe('update', () => {
+    it('should update markers if history exists', () => {
+      entityHistoryManager.historyLayerGroup.clearLayers = jest.fn();
+      entityHistoryManager.history = { update: jest.fn(() => [[{ addTo: jest.fn() }]])};
+      entityHistoryManager.update();
+      expect(entityHistoryManager.history.update).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/models/TimelineEntry.js
+++ b/src/models/TimelineEntry.js
@@ -5,9 +5,12 @@ export default class TimelineEntry {
   entityId;
   /** @type {object} */
   state;
+  /** @type {string} */
+  originalEntityId;
 
-  constructor(timestamp, entityId, state) {  
+  constructor(timestamp, originalEntityId, entityId, state) {  
     this.timestamp = timestamp;  
+    this.originalEntityId = originalEntityId;
     this.entityId = entityId;
     this.state = state;
   }

--- a/src/models/TimelineEntry.js
+++ b/src/models/TimelineEntry.js
@@ -1,14 +1,24 @@
 export default class TimelineEntry {  
   /** @type {Date} */
   timestamp;
-  /** @type {number} */
-  latitude;
-  /** @type {number} */
-  longitude;
+  /** @type {string} */
+  entityId;
+  /** @type {object} */
+  state;
 
-  constructor(timestamp, latitude, longitude) {  
+  constructor(timestamp, entityId, state) {  
     this.timestamp = timestamp;  
-    this.latitude = latitude;  
-    this.longitude = longitude;  
-  }  
+    this.entityId = entityId;
+    this.state = state;
+  }
+
+  /** @returns {number} */
+  get latitude() {
+    return this.state.a.latitude;
+  }
+
+  /** @returns {number} */
+  get longitude() {
+    return this.state.a.longitude;
+  }
 }

--- a/src/services/HaHistoryService.js
+++ b/src/services/HaHistoryService.js
@@ -50,13 +50,13 @@ export default class HaHistoryService {
       this.connection[entityId] = this.hass.connection.subscribeMessage(
         (message) => {
           // entities providing results
-          Object.values(message.states).map((entity) => {
+          Object.entries(message.states).map(([messageEntityId, value]) => {
             // Each entity can return own results
-            entity?.map((state) => {
+            value?.map((state) => {
               // Get states from each
               if(state.a.latitude && state.a.longitude) {
-                Logger.debug("[HaHistoryService]: received new msg for entity id: " + entityId);
-                f(new TimelineEntry(new Date(state.lu * 1000), state.entityId, state));
+                Logger.debug("[HaHistoryService]: received new msg for entity id: " + messageEntityId + " for entity: " + entityId);
+                f(new TimelineEntry(new Date(state.lu * 1000), entityId, messageEntityId, state));
               } else {
                 Logger.warn("[HaHistoryService]: received new msg without latitude/longitude for entity id: " + entityId);
               }

--- a/src/services/HaHistoryService.js
+++ b/src/services/HaHistoryService.js
@@ -56,7 +56,7 @@ export default class HaHistoryService {
               // Get states from each
               if(state.a.latitude && state.a.longitude) {
                 Logger.debug("[HaHistoryService]: received new msg for entity id: " + entityId);
-                f(new TimelineEntry(new Date(state.lu * 1000), state.a.latitude, state.a.longitude));
+                f(new TimelineEntry(new Date(state.lu * 1000), state.entityId, state));
               } else {
                 Logger.warn("[HaHistoryService]: received new msg without latitude/longitude for entity id: " + entityId);
               }


### PR DESCRIPTION
Implementation of #120 
Fixing bug of #121

This introduces a new functionality, when using the Date Range Manager it will show the last state & location within the range. It also updates the marker to the current location on new events.