### PR TITLE
Update _generateRandomColor to produce entity-bound pseudorandom colors

### DIFF
--- a/src/configs/EntityConfig.js
+++ b/src/configs/EntityConfig.js
@@ -166,6 +166,8 @@ export default class EntityConfig {
   _generateRandomColor() {
     // Generate pseudo-random color from provided entity id
     let str = this.id;
+    
+    // Generate a BigInt numeric hash of the string provided.
     // 53-bit hash based on cyrb53 (c) 2018 bryc (github.com/bryc). 
     // License: Public domain, https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js
     let h1 = 0xdeadbeef, h2 = 0x41c6ce57;
@@ -179,6 +181,10 @@ export default class EntityConfig {
     h2  = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
     h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
     let hash =  4294967296 * (2097151 & h2) + (h1 >>> 0);
+
+    // Now that we have a numeric hash, construct a CSS hsl() color with hue derived from the hash above (hash % 360), 95% saturation and 35% lightness.
+    // Unlike the simplified RGB approach (#RRGGBB) this method produces colors with similar saturation and lightness, resulting in a more aesthetically pleasing palette.
+    // N.B. hue value might be computed to a negative number which is not strictly allowed in HSL palette - but CSS handles these cases well.
     let color = `hsl(${hash % 360}, 95%, 35%)`;
     return color;
   }

--- a/src/configs/EntityConfig.js
+++ b/src/configs/EntityConfig.js
@@ -164,6 +164,22 @@ export default class EntityConfig {
   }  
 
   _generateRandomColor() {
-    return "#" + ((1 << 24) * Math.random() | 0).toString(16).padStart(6, "0");
+    // Generate pseudo-random color from provided entity id
+    let str = this.id;
+    // 53-bit hash based on cyrb53 (c) 2018 bryc (github.com/bryc). 
+    // License: Public domain, https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js
+    let h1 = 0xdeadbeef, h2 = 0x41c6ce57;
+    for(let i = 0, ch; i < str.length; i++) {
+      ch = str.charCodeAt(i);
+      h1 = Math.imul(h1 ^ ch, 2654435761);
+      h2 = Math.imul(h2 ^ ch, 1597334677);
+    }
+    h1  = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+    h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+    h2  = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+    h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+    let hash =  4294967296 * (2097151 & h2) + (h1 >>> 0);
+    let color = `hsl(${hash % 360}, 95%, 35%)`;
+    return color;
   }
 }

--- a/src/configs/EntityConfig.test.js
+++ b/src/configs/EntityConfig.test.js
@@ -1,0 +1,33 @@
+import EntityConfig from "./EntityConfig";
+import { describe, expect, it } from "@jest/globals";
+
+describe("EntityConfig", () => {
+
+  const defaults = {
+    historyStart: null,
+    historyEnd: null
+  };
+
+  describe("_generateRandomColor", () => {
+    it("should generate a random color", () => {
+      const entityConfig = new EntityConfig("sensor.random_entity", defaults);
+      
+      const color = entityConfig._generateRandomColor();
+
+      expect(color).toMatch(/^hsl\(\s*(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*\)$/);
+      expect(color).toBe('hsl(297, 95%, 35%)');
+      expect(entityConfig.color).toBe(color);
+      
+    });
+
+    it("should return a color if defined", () => {
+      const entityConfig = new EntityConfig({
+        id: "sensor.random_entity",
+        color: "red"
+       }, defaults);
+
+      expect(entityConfig.color).toBe("red");
+
+    });
+  });
+});


### PR DESCRIPTION
The issue: different users, or even the same user on different devices, will see entities on map colorized in a random and inconsistent manner - even a browser refresh changes the colors.

This PR proposes a rewrite of _generateRandomColor() function to use entity ID as the seed for entity color, thus providing consistent colors for different browser sessions or users.

As I'm not a real JS developer - code is based on StackOverflow answers and  small cryptographic hash function cyrb53 (Public domain, https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js )