### PR TITLE
Add plugin loading from HACS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,13 @@ More complex use of the WMS/Tile history property can be configured within the h
 | name      | note                                                                                                                                                        |
 |-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `name`  | Mandatory, a helpful name for this instance of the plugin. Useful for debugging issues. |
-| `url`     | Mandatory, The url of the plugin, if the plugin is in the file `/var/lib/hass/www/SomePlugin.js` , then this would be `./local/SomePlugin.js`. |
+| `url`     | The url of the plugin, if the plugin is in the file `/var/lib/hass/www/SomePlugin.js` , then this would be `./local/SomePlugin.js`. |
+| `hacs.module` | The HACS module from which the plugin must be loaded if `url` is not set. |
+| `hacs.file` | The file within the module from which the plugin must be loaded if `url is not set. |
 | `options` | Options for configuring the plugin |
 
+The `url` option is used when set.
+If the `url` is not set and the `hacs` object is, the plugin will be loaded from the [HACS plugin](https://hacs.xyz/docs/publish/plugin/) with the given name and given filename.
 
 
 #### Example config with plugin
@@ -235,6 +239,7 @@ This project uses [devenv.sh](https://devenv.sh/).
 * All plugins should implement the `Plugin` class. See [`Plugin.js`](./src/models/Plugin.js) and [`Plugin.d.ts`](./src/models/Plugin.d.ts).
 * For a concrete example, see [`CircleTestPlugin.js`](./plugins/CircleTestPlugin.js).
 * Typescript example: see [bezmi/ha-map-card-plugin-bom-radar](https://github.com/bezmi/ha-map-card-plugin-bom-radar).
+* For an example HACS plugin installation: see [`buienradar`](https://github.com/Kevinjil/ha-map-card-buienradar).
 
 Tag your Github repo with [ha-map-card-plugin](https://github.com/topics/ha-map-card-plugin) for discoverability.
 

--- a/src/configs/MapConfig.js
+++ b/src/configs/MapConfig.js
@@ -104,7 +104,7 @@ export default class MapConfig {
     // Allow as none array
     let plugins = this._setConfigWithDefault(inputConfig.plugins, []);
     this.plugins = (this._setConfigWithDefault(Array.isArray(plugins) ? plugins : [plugins], [])).map((plugin) => {
-      return new PluginConfig(plugin.url, plugin.name, plugin.options);
+      return new PluginConfig(plugin.hacs, plugin.url, plugin.name, plugin.options);
     });
 
     this.tileLayer = new TileLayerConfig(

--- a/src/configs/PluginConfig.js
+++ b/src/configs/PluginConfig.js
@@ -1,20 +1,24 @@
 import Logger from "../util/Logger";
 
+
 export default class PluginConfig {
-  /** @type {string} */
+  /** @type {{module: string, file: string} | undefined} */
+  hacs;
+  /** @type {string | undefined} */
   url;
   /** @type {string} */
   name;
   /** @type {object} */
   options;
 
-  constructor(url, name, options) {
+  constructor(hacs, url, name, options) {
+    this.hacs = hacs,
     this.url = url;
     this.name = name;
     this.options = { ...options };
 
     Logger.debug(
-      `[PluginConfig]: created with url: ${this.url}, name: ${this.name}, options: ${this.options}`
+      `[PluginConfig]: created with hacs: ${this.hacs}, url: ${this.url}, name: ${this.name}, options: ${this.options}`
     );
   }
 }

--- a/src/services/render/PluginsRenderService.js
+++ b/src/services/render/PluginsRenderService.js
@@ -56,8 +56,22 @@ export default class PluginsRenderService {
         return;
       }
 
+      let url = config.url;
+      if (url === undefined && config.hacs) {
+        const module = document.querySelectorAll("script[src][type='module']")
+            .values()
+            .find(m => new URL(m.src).pathname.includes(`/hacsfiles/${config.hacs.module}/${config.hacs.file}`));
+
+        if (!module) {
+          Logger.warn(`[PluginsRenderService] Could not find HACS file for plugin ${config.name}. Check your configuration.`);
+          return
+        }
+
+        url = module.src;
+      }
+
       // Dynamically import the plugin module from the URL
-      const module = await import(config.url);
+      const module = await import(url);
 
       const pluginFactory = module.default;
 


### PR DESCRIPTION
Adds loading of plugins directly from a HACS module instead of a URL. This assumes that the user has installed the HACS plugin referenced, and shows a configuration error if the module file cannot be found. The main benefits are:
- HACS deals with changing the URL and thus invalidating the front-end cache in case of plugin updates.
- The plugin source is preloaded resulting in faster load times for the map.
- The configuration is easier to understand when compared to the `url`.

Example configuration using [buienradar](https://github.com/Kevinjil/ha-map-card-buienradar):
```yaml
plugins:
  - name: buienradar
    hacs:
      module: ha-map-card-buienradar
      file: ha-map-card-buienradar.js
    options:
      delaySeconds: 0.5
      imageRange:
        history: 4
        forecast: 36
        skip: 0
      opacity: 0.7
      refreshSeconds: 300
```