### PR TITLE
Add "display: attribute" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Either the name of the `entity` or:
 | `picture`              |                                       | Set a custom picture to use on the marker.                                                    |
 | `icon`                 |                                       | Set a custom icon to use if `display` is set to `icon`. e.g. `mdi:cake`                           |
 | `attribute`            |                                       | Set an attribute to use if `display` is set to `attribute`. e.g. `speed`                |
+| `prefix`            |                                       | Optional prefix for a value if `display` is set to `attribute`                |
+| `suffix`            |                                       | Optional suffix for a value if `display` is set to `attribute`                |
 | `size`                 | 48                                    | Size of the icon                                                                              |
 | `color`                | Random Color                          | Can defined as `red`, `rgb(255,0,0)`, `rgba(255,0,0,0.1)`, `#ff0000`, `var(--red-color)`      |
 | `css`                  | `text-align: center; font-size: 60%;` | CSS for the marker (only for `state` and `marker`)                                            |

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Either the name of the `entity` or:
 | `display`              | `marker`                              | `icon`, `state`, `attribute` or `marker`. <br/>`marker` will display the picture if available. <br/>`icon` will display the icon if available, otherwise a label composed of first letters of the entity's name |
 | `picture`              |                                       | Set a custom picture to use on the marker.                                                    |
 | `icon`                 |                                       | Set a custom icon to use if display is set to `icon`. e.g. `mdi:cake`                           |
-| `attribute`            |                                       | Set an attribute to use if display is set to `attribute`. e.g. `friendly_name`                |
+| `attribute`            |                                       | Set an attribute to use if display is set to `attribute`. e.g. `speed`                |
 | `size`                 | 48                                    | Size of the icon                                                                              |
 | `color`                | Random Color                          | Can defined as `red`, `rgb(255,0,0)`, `rgba(255,0,0,0.1)`, `#ff0000`, `var(--red-color)`      |
 | `css`                  | `text-align: center; font-size: 60%;` | CSS for the marker (only for `state` and `marker`)                                            |

--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ Either the name of the `entity` or:
 | name                   | Default                               | note                                                                                          |
 |------------------------|---------------------------------------|-----------------------------------------------------------------------------------------------|
 | `entity`               |                                       | The entity id                                                                                 |
-| `display`              | `marker`                              | `icon`, `state` or `marker`. <br/>`marker` will display the picture if available. <br/>`icon` will display the icon if available, otherwise a label composed of first letters of the entity's name. |
+| `display`              | `marker`                              | `icon`, `state`, `attribute` or `marker`. <br/>`marker` will display the picture if available. <br/>`icon` will display the icon if available, otherwise a label composed of first letters of the entity's name. <br/>`attribute` will fallback to `icon` if a defined `attribute` is not available |
 | `picture`              |                                       | Set a custom picture to use on the marker.                                                    |
-| `icon`                 |                                       | Set a custom icon to use if display is set to `icon`. e.g. mdi:cake                           |
+| `icon`                 |                                       | Set a custom icon to use if display is set to `icon`. e.g. `mdi:cake`                           |
+| `attribute`            |                                       | Set an attribute to use if display is set to `attribute`. e.g. `friendly_name`                |
 | `size`                 | 48                                    | Size of the icon                                                                              |
 | `color`                | Random Color                          | Can defined as `red`, `rgb(255,0,0)`, `rgba(255,0,0,0.1)`, `#ff0000`, `var(--red-color)`      |
 | `css`                  | `text-align: center; font-size: 60%;` | CSS for the marker (only for `state` and `marker`)                                            |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Either the name of the `entity` or:
 | name                   | Default                               | note                                                                                          |
 |------------------------|---------------------------------------|-----------------------------------------------------------------------------------------------|
 | `entity`               |                                       | The entity id                                                                                 |
-| `display`              | `marker`                              | `icon`, `state`, `attribute` or `marker`. <br/>`marker` will display the picture if available. <br/>`icon` will display the icon if available, otherwise a label composed of first letters of the entity's name. <br/>`attribute` will fallback to `icon` if a defined `attribute` is not available |
+| `display`              | `marker`                              | `icon`, `state`, `attribute` or `marker`. <br/>`marker` will display the picture if available. <br/>`icon` will display the icon if available, otherwise a label composed of first letters of the entity's name |
 | `picture`              |                                       | Set a custom picture to use on the marker.                                                    |
 | `icon`                 |                                       | Set a custom icon to use if display is set to `icon`. e.g. `mdi:cake`                           |
 | `attribute`            |                                       | Set an attribute to use if display is set to `attribute`. e.g. `friendly_name`                |

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Either the name of the `entity` or:
 | `entity`               |                                       | The entity id                                                                                 |
 | `display`              | `marker`                              | `icon`, `state`, `attribute` or `marker`. <br/>`marker` will display the picture if available. <br/>`icon` will display the icon if available, otherwise a label composed of first letters of the entity's name |
 | `picture`              |                                       | Set a custom picture to use on the marker.                                                    |
-| `icon`                 |                                       | Set a custom icon to use if display is set to `icon`. e.g. `mdi:cake`                           |
-| `attribute`            |                                       | Set an attribute to use if display is set to `attribute`. e.g. `speed`                |
+| `icon`                 |                                       | Set a custom icon to use if `display` is set to `icon`. e.g. `mdi:cake`                           |
+| `attribute`            |                                       | Set an attribute to use if `display` is set to `attribute`. e.g. `speed`                |
 | `size`                 | 48                                    | Size of the icon                                                                              |
 | `color`                | Random Color                          | Can defined as `red`, `rgb(255,0,0)`, `rgba(255,0,0,0.1)`, `#ff0000`, `var(--red-color)`      |
 | `css`                  | `text-align: center; font-size: 60%;` | CSS for the marker (only for `state` and `marker`)                                            |

--- a/src/components/MapCardEntityMarker.js
+++ b/src/components/MapCardEntityMarker.js
@@ -92,10 +92,10 @@ export default class MapCardEntityMarker extends LitElement {
         background: #1c1c1c;
       }
       .prefix {
-        margin-left: var(--ha-marker-prefix-margin, 2px);
+        margin-right: var(--ha-marker-prefix-margin, 2px);
       }
       .suffix {
-        margin-right: var(--ha-marker-suffix-margin, 2px);
+        margin-left: var(--ha-marker-suffix-margin, 2px);
       }
     `;
   }

--- a/src/components/MapCardEntityMarker.js
+++ b/src/components/MapCardEntityMarker.js
@@ -5,6 +5,8 @@ export default class MapCardEntityMarker extends LitElement {
     return {
       'entityId': {type: String, attribute: 'entity-id'},
       'title': {type: String, attribute: 'title'},
+      'prefix': {type: String, attribute: 'prefix'},
+      'suffix': {type: String, attribute: 'suffix'},
       'tooltip': {type: String, attribute: 'tooltip'},
       'picture': {type: String, attribute: 'picture'},
       'icon': {type: String, attribute: 'icon'},
@@ -51,7 +53,15 @@ export default class MapCardEntityMarker extends LitElement {
     if(this.icon) {
       return html`<ha-icon icon="${this.icon}" style="--icon-primary-color: ${this.color}; --mdc-icon-size: ${this.size - 10}px;">icon</ha-icon>`
     }
-    return this.title;
+    if (!this.prefix && !this.suffix) {
+      return this.title;
+    } else {
+      return html`
+        <span class="prefix" style="display: ${this.prefix ? 'initial' : 'none'}">${this.prefix}</span>
+        ${this.title}
+        <span class="suffix" style="display: ${this.suffix ? 'initial' : 'none'}">${this.suffix}</span>
+      `;
+    }
   }
 
   static get styles() {
@@ -80,6 +90,12 @@ export default class MapCardEntityMarker extends LitElement {
       .marker.dark {
         color: #ffffff;
         background: #1c1c1c;
+      }
+      .prefix {
+        margin-left: var(--ha-marker-prefix-margin, 2px);
+      }
+      .suffix {
+        margin-right: var(--ha-marker-suffix-margin, 2px);
       }
     `;
   }

--- a/src/configs/EntityConfig.js
+++ b/src/configs/EntityConfig.js
@@ -70,8 +70,8 @@ export default class EntityConfig {
     this.id = (typeof config === 'string' || config instanceof String)? config : config.entity;
     this.display = config.display ? config.display : "marker";
     this.attribute = config.attribute ? config.attribute : "";
-    this.prefix = config.prefix ? config.prefix : "";
-    this.suffix = config.suffix ? config.suffix : "";
+    this.prefix = config.display === "attribute" ? (config.prefix ? config.prefix : "") : "";
+    this.suffix = config.display === "attribute" ? (config.suffix ? config.suffix : "") : "";
     this.size = config.size ? config.size : 48;
     // If historyLineColor not set, inherit icon color
     this.color = config.color ?? this._generateRandomColor();

--- a/src/configs/EntityConfig.js
+++ b/src/configs/EntityConfig.js
@@ -65,6 +65,7 @@ export default class EntityConfig {
   constructor(config, defaults) {
     this.id = (typeof config === 'string' || config instanceof String)? config : config.entity;
     this.display = config.display ? config.display : "marker";
+    this.attribute = config.attribute ? config.attribute : "";
     this.size = config.size ? config.size : 48;
     // If historyLineColor not set, inherit icon color
     this.color = config.color ?? this._generateRandomColor();

--- a/src/configs/EntityConfig.js
+++ b/src/configs/EntityConfig.js
@@ -7,6 +7,8 @@ export default class EntityConfig {
   id;
   /** @type {string} */
   display;
+  /** @type {string} */
+  attribute;
   /** @type {number} */
   size;
   /** @type {Date} */
@@ -112,7 +114,7 @@ export default class EntityConfig {
 
     this.circleConfig = new CircleConfig(config.circle, this.color);
     Logger.debug(
-      `[EntityConfig]: created with id: ${this.id}, display: ${this.display}, size: ${this.size}, historyStart: ${this.historyStart}, historyEnd: ${this.historyEnd}, historyStartEntity: ${this.historyStartEntity}, historyEndEntity: ${this.historyEndEntity}, historyLineColor: ${this.historyLineColor}, historyShowDots: ${this.historyShowDots}, historyShowLines: ${this.historyShowLines}, fixedX: ${this.fixedX}, fixedY: ${this.fixedY}, fallbackX: ${this.fallbackX}, fallbackY: ${this.fallbackY}, css: ${this.css}, picture: ${this.picture}, icon: ${this.icon}, color: ${this.color}, gradualOpacity: ${this.gradualOpacity}, tapAction: ${this.tapAction}, focusOnFit: ${this.focusOnFit}, zIndexOffset: ${this.zIndexOffset}, useBaseEntityOnly: ${this.useBaseEntityOnly}, circleConfig: ${this.circleConfig}`
+      `[EntityConfig]: created with id: ${this.id}, display: ${this.display}, attribute: ${this.attribute}, size: ${this.size}, historyStart: ${this.historyStart}, historyEnd: ${this.historyEnd}, historyStartEntity: ${this.historyStartEntity}, historyEndEntity: ${this.historyEndEntity}, historyLineColor: ${this.historyLineColor}, historyShowDots: ${this.historyShowDots}, historyShowLines: ${this.historyShowLines}, fixedX: ${this.fixedX}, fixedY: ${this.fixedY}, fallbackX: ${this.fallbackX}, fallbackY: ${this.fallbackY}, css: ${this.css}, picture: ${this.picture}, icon: ${this.icon}, color: ${this.color}, gradualOpacity: ${this.gradualOpacity}, tapAction: ${this.tapAction}, focusOnFit: ${this.focusOnFit}, zIndexOffset: ${this.zIndexOffset}, useBaseEntityOnly: ${this.useBaseEntityOnly}, circleConfig: ${this.circleConfig}`
     );
   }
 

--- a/src/configs/EntityConfig.js
+++ b/src/configs/EntityConfig.js
@@ -9,6 +9,10 @@ export default class EntityConfig {
   display;
   /** @type {string} */
   attribute;
+  /** @type {string} */
+  prefix;
+  /** @type {string} */
+  suffix;
   /** @type {number} */
   size;
   /** @type {Date} */
@@ -66,6 +70,8 @@ export default class EntityConfig {
     this.id = (typeof config === 'string' || config instanceof String)? config : config.entity;
     this.display = config.display ? config.display : "marker";
     this.attribute = config.attribute ? config.attribute : "";
+    this.prefix = config.prefix ? config.prefix : "";
+    this.suffix = config.suffix ? config.suffix : "";
     this.size = config.size ? config.size : 48;
     // If historyLineColor not set, inherit icon color
     this.color = config.color ?? this._generateRandomColor();
@@ -115,7 +121,7 @@ export default class EntityConfig {
 
     this.circleConfig = new CircleConfig(config.circle, this.color);
     Logger.debug(
-      `[EntityConfig]: created with id: ${this.id}, display: ${this.display}, attribute: ${this.attribute}, size: ${this.size}, historyStart: ${this.historyStart}, historyEnd: ${this.historyEnd}, historyStartEntity: ${this.historyStartEntity}, historyEndEntity: ${this.historyEndEntity}, historyLineColor: ${this.historyLineColor}, historyShowDots: ${this.historyShowDots}, historyShowLines: ${this.historyShowLines}, fixedX: ${this.fixedX}, fixedY: ${this.fixedY}, fallbackX: ${this.fallbackX}, fallbackY: ${this.fallbackY}, css: ${this.css}, picture: ${this.picture}, icon: ${this.icon}, color: ${this.color}, gradualOpacity: ${this.gradualOpacity}, tapAction: ${this.tapAction}, focusOnFit: ${this.focusOnFit}, zIndexOffset: ${this.zIndexOffset}, useBaseEntityOnly: ${this.useBaseEntityOnly}, circleConfig: ${this.circleConfig}`
+      `[EntityConfig]: created with id: ${this.id}, display: ${this.display}, attribute: ${this.attribute}, prefix: ${this.prefix}, suffix: ${this.suffix}, size: ${this.size}, historyStart: ${this.historyStart}, historyEnd: ${this.historyEnd}, historyStartEntity: ${this.historyStartEntity}, historyEndEntity: ${this.historyEndEntity}, historyLineColor: ${this.historyLineColor}, historyShowDots: ${this.historyShowDots}, historyShowLines: ${this.historyShowLines}, fixedX: ${this.fixedX}, fixedY: ${this.fixedY}, fallbackX: ${this.fallbackX}, fallbackY: ${this.fallbackY}, css: ${this.css}, picture: ${this.picture}, icon: ${this.icon}, color: ${this.color}, gradualOpacity: ${this.gradualOpacity}, tapAction: ${this.tapAction}, focusOnFit: ${this.focusOnFit}, zIndexOffset: ${this.zIndexOffset}, useBaseEntityOnly: ${this.useBaseEntityOnly}, circleConfig: ${this.circleConfig}`
     );
   }
 

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -222,8 +222,8 @@ export default class Entity {
           <map-card-entity-marker
             entity-id="${this.id}"
             title="${this.title}"
-            prefix="${this.prefix}"
-            suffix="${this.suffix}"
+            prefix="${this.config.prefix}"
+            suffix="${this.config.suffix}"
             tooltip="${this.tooltip}"
             icon="${icon ?? ""}"
             picture="${picture ?? ""}"

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -159,10 +159,10 @@ export default class Entity {
       return this.state;
     }
     if(this.display == "attribute") {
-      if(this.config.attribute && this.attributes[this.config.attribute])
+      // if(this.config.attribute && this.attributes[this.config.attribute])
         return this.attributes[this.config.attribute];
-      else
-        return "?";
+      // else
+        // return "?";
     }
     const title = this.friendlyName;
     if(title.length < 5) {

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -61,7 +61,7 @@ export default class Entity {
     this.map = map;
     this.darkMode = darkMode;
 
-    if(this.display == "state") {
+    if(this.display == "state" || this.display == "attribute") {
       this._currentTitle = this.title;
     }
     this.circle = new Circle(this.config.circleConfig, this);
@@ -158,6 +158,12 @@ export default class Entity {
     if(this.display == "state") {
       return this.state;
     }
+    if(this.display == "attribute") {
+      if(this.config.attribute && this.attributes[this.config.attribute])
+        return this.attributes[this.config.attribute];
+      else
+        return "?";
+    }
     const title = this.friendlyName;
     if(title.length < 5) {
       return title;
@@ -181,9 +187,9 @@ export default class Entity {
   }  
 
   async update() {
-    if(this.display == "state") {
+    if(this.display == "state" || this.display == "attribute") {
       if(this.title != this._currentTitle) {
-        Logger.debug("[Entity] updating marker for " + this.id + " from " + this._currentTitle + " to " + this.state);
+        Logger.debug("[Entity] updating marker for " + this.id + " from " + this._currentTitle + " to " + this.title);
         this.marker.remove();
         this.marker = this.createMapMarker();
         this.marker.addTo(this.map);
@@ -206,7 +212,7 @@ export default class Entity {
     if(this.display == "icon") {
       picture = null;
     }
-    if(this.display == "state") {
+    if(this.display == "state" || this.display == "attribute") {
       picture = null;
       icon = null;
     }

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -159,10 +159,7 @@ export default class Entity {
       return this.state;
     }
     if(this.display == "attribute") {
-      // if(this.config.attribute && this.attributes[this.config.attribute])
-        return this.attributes[this.config.attribute];
-      // else
-        // return "?";
+      return this.attributes[this.config.attribute];
     }
     const title = this.friendlyName;
     if(title.length < 5) {

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -159,7 +159,7 @@ export default class Entity {
       return this.state;
     }
     if(this.display == "attribute") {
-      return this.attributes[this.config.attribute];
+      return this.hass.formatEntityAttributeValue(this.hass.states[this.id], this.config.attribute);
     }
     const title = this.friendlyName;
     if(title.length < 5) {

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -222,6 +222,8 @@ export default class Entity {
           <map-card-entity-marker
             entity-id="${this.id}"
             title="${this.title}"
+            prefix="${this.prefix}"
+            suffix="${this.suffix}"
             tooltip="${this.tooltip}"
             icon="${icon ?? ""}"
             picture="${picture ?? ""}"


### PR DESCRIPTION
Added `display: attribute` feature.

Notes:
1. These commented lines in `get title()`:
```
    if(this.display == "attribute") {
      // if(this.config.attribute && this.attributes[this.config.attribute])
        return this.attributes[this.config.attribute];
      // else
        // return "?";
    }
```
Currently an "undefined" label is shown if an attribute is missing. We can show some "fallback" value like "?".
Update: comments removed in https://github.com/nathan-gs/ha-map-card/pull/139/commits/0789359ca563497eaf35643044ed5680a4586ac6.

2. ~A value of an attribute is shown w/o any localization (as is). For numerical values it also causes a default format.~ Update: fixed in https://github.com/nathan-gs/ha-map-card/pull/139/commits/efe0a9ad5d0bbbbd812a7acf519933ba875ddf79
