### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hacs-validate.yml
+++ b/.github/workflows/hacs-validate.yml
@@ -1,5 +1,8 @@
 name: HACS Validate
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/nathan-gs/ha-map-card/security/code-scanning/2](https://github.com/nathan-gs/ha-map-card/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for most validation workflows. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
