### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/showcase.yml
+++ b/.github/workflows/showcase.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'showcase/**'
 
+permissions:
+  contents: read
+
 jobs:
   validate-readmes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nathan-gs/ha-map-card/security/code-scanning/1](https://github.com/nathan-gs/ha-map-card/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly set `contents: read`, which is the minimum required permission for this workflow. This ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
