### PR TITLE
Add marker clustering, custom labels, and position update threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Either the name of the `entity` or:
 | `display`              | `marker`                              | `icon`, `state`, `attribute` or `marker`. <br/>`marker` will display the picture if available. <br/>`icon` will display the icon if available, otherwise a label composed of first letters of the entity's name |
 | `picture`              |                                       | Set a custom picture to use on the marker.                                                    |
 | `icon`                 |                                       | Set a custom icon to use if `display` is set to `icon`. e.g. `mdi:cake`                           |
+| `label`                |                                       | Set a custom text label to display on the marker (overrides auto-generated initials). Works with picture overlays.                |
 | `attribute`            |                                       | Set an attribute to use if `display` is set to `attribute`. e.g. `speed`                |
 | `prefix`            |                                       | Optional prefix for a value if `display` is set to `attribute`                |
 | `suffix`            |                                       | Optional suffix for a value if `display` is set to `attribute`                |
@@ -104,6 +105,7 @@ Either the name of the `entity` or:
 | `focus_on_fit`         | true                                  | If this variable is set to false, This entity will be excluded when the map fits the included entities on the screen.|
 | `z_index_offset`       | 1                                     | z-index value that determines what is displayed on top when markers overlap. (Setting a gap of at least 20 between the values assigned to each entity is recommended.) |
 | `use_base_entity_only` | false                                 | When set to `true`, the tracking will use only the base entity without including any associated device trackers. This is useful for scenarios where you want to track the base entity directly and ignore any associated trackers. |
+| `position_update_threshold` | 10                               | Distance threshold in meters. Marker position only updates if the entity has moved more than this distance. Prevents unnecessary map updates from GPS drift. Useful for clustered markers. |
 | `circle`               |                                       | Display a circle around the marker. <br/>More details [Circle options](#circle-options) |
 
 ### History options

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ y: 3.652
 | `theme_mode`          | auto                                  | `auto`, `light` or`dark`                                                                      |
 | `focus_follow`        | none                                  | `none`, `refocus`, `contains`, reset the map focused entity's, on each update. Some people call this the `Autofit` feature.                                                              |
 | `map_options`          | {}                                                                                                                           | The `options` for the default [Leaflet Map](https://leafletjs.com/reference.html#map) |
+| `cluster_markers`      | true                                                                                                                         | Enable marker clustering to group nearby entities together. Click the group icon button to toggle clustering on/off. |
 | `debug` | false                                                                                                                        | Enable debug messages in console.
 | `plugins`            | []                                                                                                                           | An array of plugin definitions, see: [Plugin Options](#plugin-options), [Available plugins](#available-plugins) and [Developing plugins](#developing-plugins)     |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "leaflet": "^1.9.4",
+        "leaflet.markercluster": "^1.5.3",
         "lit": "^3.1.3"
       },
       "devDependencies": {
@@ -5725,6 +5726,15 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/leaflet.markercluster": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "leaflet": "^1.3.1"
+      }
     },
     "node_modules/leven": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/nathan-gs/ha-map-card#readme",
   "dependencies": {
     "leaflet": "^1.9.4",
+    "leaflet.markercluster": "^1.5.3",
     "lit": "^3.1.3"
   },
   "devDependencies": {

--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -64,7 +64,7 @@ export default class MapCard extends LitElement {
       this.dateRangeManager = new HaDateRangeService(this.hass);
     }
     this.tileLayersService = new TileLayersService(this.map, this._config.tileLayers, this._config.wms, this.urlResolver, this.linkedEntityService, this.dateRangeManager);
-    this.entitiesRenderService = new EntitiesRenderService(this.map, this.hass, this._config.focusFollow, this._config.entities, this.linkedEntityService, this.dateRangeManager, this.historyService, this._isDarkMode());
+    this.entitiesRenderService = new EntitiesRenderService(this.map, this.hass, this._config.focusFollow, this._config.entities, this.linkedEntityService, this.dateRangeManager, this.historyService, this._isDarkMode(), this._config.clusterMarkers);
     this.initialViewRenderService = new InitialViewRenderService(this.map, this._config, this.hass, this.entitiesRenderService);
 
     this.pluginsRenderService = new PluginsRenderService(this.map, this._config.plugins);
@@ -112,6 +112,8 @@ export default class MapCard extends LitElement {
 
     return html`
             <link rel="stylesheet" href="/static/images/leaflet/leaflet.css">
+            <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css">
+            <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css">
             <ha-card header="${this._config.title}">
               <div id="mapContainer">
                 <div id="map" style="min-height: ${this._config.mapHeight}px">
@@ -123,6 +125,16 @@ export default class MapCard extends LitElement {
                   >
                     <ha-icon icon="mdi:image-filter-center-focus"></ha-icon>
                   </ha-icon-button>
+                  ${this._config.clusterMarkers ? html`
+                    <ha-icon-button
+                      label='Toggle grouping'
+                      style='${this._isDarkMode() ? "color:#ffffff;" : "color:#000000;"} position: absolute; top: 115px; left: 3px; z-index: 1;'
+                      @click=${this._toggleClustering}
+                      tabindex="0"
+                    >
+                      <ha-icon icon="mdi:group"></ha-icon>
+                    </ha-icon-button>
+                  ` : ''}
                 </div>
               </div>
             </ha-card>
@@ -131,6 +143,10 @@ export default class MapCard extends LitElement {
 
   _fitMap() {
     this.initialViewRenderService.setup();
+  }
+
+  _toggleClustering() {
+    this.entitiesRenderService.toggleClustering();
   }
 
   _setupResizeObserver() {

--- a/src/components/MapCardEntityMarker.js
+++ b/src/components/MapCardEntityMarker.js
@@ -48,7 +48,18 @@ export default class MapCardEntityMarker extends LitElement {
 
   _inner() {
     if(this.picture) {
-      return html`<div class="entity-picture" style="background-image: url(${this.picture})"></div>`
+      // Show picture with optional label overlay
+      const hasLabel = this.title && (this.prefix || this.suffix || this.title.trim());
+      return html`
+        <div class="entity-picture" style="background-image: url(${this.picture})"></div>
+        ${hasLabel ? html`
+          <div class="picture-label">
+            <span class="prefix" style="display: ${this.prefix ? 'initial' : 'none'}">${this.prefix}</span>
+            ${this.title}
+            <span class="suffix" style="display: ${this.suffix ? 'initial' : 'none'}">${this.suffix}</span>
+          </div>
+        ` : ''}
+      `;
     }
     if(this.icon) {
       return html`<ha-icon icon="${this.icon}" style="--icon-primary-color: ${this.color}; --mdc-icon-size: ${this.size - 10}px;">icon</ha-icon>`
@@ -78,6 +89,7 @@ export default class MapCardEntityMarker extends LitElement {
         border: 1px solid var(--ha-marker-color, var(--primary-color));
         color: var(--primary-text-color);
         background-color: var(--card-background-color);
+        position: relative;
       }
       .marker.picture {
         overflow: hidden;
@@ -86,6 +98,20 @@ export default class MapCardEntityMarker extends LitElement {
         background-size: cover;
         height: 100%;
         width: 100%;
+      }
+      .picture-label {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background: rgba(0, 0, 0, 0.6);
+        color: white;
+        padding: 2px 4px;
+        font-size: 0.7em;
+        text-align: center;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .marker.dark {
         color: #ffffff;

--- a/src/configs/EntityConfig.js
+++ b/src/configs/EntityConfig.js
@@ -13,6 +13,8 @@ export default class EntityConfig {
   prefix;
   /** @type {string} */
   suffix;
+  /** @type {string} */
+  label;
   /** @type {number} */
   size;
   /** @type {Date} */
@@ -62,7 +64,9 @@ export default class EntityConfig {
   zIndexOffset;
   /** @type {boolean} */
   useBaseEntityOnly;
-  
+  /** @type {number} */
+  positionUpdateThreshold;
+
   /** @type {CircleConfig} */
   circleConfig;
 
@@ -72,6 +76,7 @@ export default class EntityConfig {
     this.attribute = config.attribute ? config.attribute : "";
     this.prefix = config.display === "attribute" ? (config.prefix ? config.prefix : "") : "";
     this.suffix = config.display === "attribute" ? (config.suffix ? config.suffix : "") : "";
+    this.label = config.label ?? null;
     this.size = config.size ? config.size : 48;
     // If historyLineColor not set, inherit icon color
     this.color = config.color ?? this._generateRandomColor();
@@ -118,6 +123,7 @@ export default class EntityConfig {
     this.zIndexOffset = config.z_index_offset ? config.z_index_offset : 1;
 
     this.useBaseEntityOnly = config.use_base_entity_only ?? false;
+    this.positionUpdateThreshold = config.position_update_threshold ?? 10;
 
     this.circleConfig = new CircleConfig(config.circle, this.color);
     Logger.debug(

--- a/src/configs/MapConfig.js
+++ b/src/configs/MapConfig.js
@@ -41,6 +41,8 @@ export default class MapConfig {
   mapOptions;
   /** @type {FocusFollowConfig} */
   focusFollow;
+  /** @type {boolean} */
+  clusterMarkers;
 
   /** @type {boolean} */
   debug = false;
@@ -57,6 +59,9 @@ export default class MapConfig {
 
     // Get theme mode.
     this.themeMode = ['dark', 'light', 'auto'].includes(inputConfig.theme_mode) ? inputConfig.theme_mode : 'auto';
+
+    // Enable marker clustering (default: true)
+    this.clusterMarkers = this._setConfigWithDefault(inputConfig.cluster_markers, true);
 
     // Enable debug messaging. 
     // Card is quite chatty with this enabled.

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -134,9 +134,15 @@ export default class Entity {
     throw Error("Entity: " + this.id + " has no latitude & longitude and no fallback configured")
   }
 
-  setup() {
+  setup(clusterGroup = null) {
     this.marker = this.createMapMarker();
-    this.marker.addTo(this.map);
+    if (clusterGroup) {
+      Logger.debug("[Entity] Adding marker for " + this.id + " to cluster group");
+      clusterGroup.addLayer(this.marker);
+    } else {
+      Logger.debug("[Entity] Adding marker for " + this.id + " directly to map");
+      this.marker.addTo(this.map);
+    }
     this.historyManager.setup();
     this.circle.setup();
   }
@@ -183,13 +189,17 @@ export default class Entity {
     return this.config.icon ?? this.attributes.icon;
   }  
 
-  async update() {
+  async update(clusterGroup = null) {
     if(this.display == "state" || this.display == "attribute") {
       if(this.title != this._currentTitle) {
         Logger.debug("[Entity] updating marker for " + this.id + " from " + this._currentTitle + " to " + this.title);
         this.marker.remove();
         this.marker = this.createMapMarker();
-        this.marker.addTo(this.map);
+        if (clusterGroup) {
+          clusterGroup.addLayer(this.marker);
+        } else {
+          this.marker.addTo(this.map);
+        }
         this._currentTitle = this.title;
       }
     }

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -49,11 +49,16 @@ export default class Entity {
    * @type {TimelineEntry} 
    */
   currentTimelineEntry;
-  /** 
+  /**
    * @private
-   * @type {LatLng} 
+   * @type {LatLng}
    */
-  _currentLatLng;  
+  _currentLatLng;
+  /**
+   * @private
+   * @type {LatLng}
+   */
+  _lastSetLatLng;
 
   constructor(config, hass, map, historyService, dateRangeManager, linkedEntityService, darkMode) {
     this.config = config;
@@ -143,6 +148,8 @@ export default class Entity {
       Logger.debug("[Entity] Adding marker for " + this.id + " directly to map");
       this.marker.addTo(this.map);
     }
+    // Initialize last set position to prevent immediate update
+    this._lastSetLatLng = this.latLng;
     this.historyManager.setup();
     this.circle.setup();
   }
@@ -161,6 +168,10 @@ export default class Entity {
 
   /** @returns {string} */
   get title() {
+    // Use custom label if provided
+    if(this.config.label) {
+      return this.config.label;
+    }
     if(this.display == "state") {
       return this.state;
     }
@@ -171,7 +182,7 @@ export default class Entity {
     if(title.length < 5) {
       return title;
     }
-    const regex = /[ _/-]/; 
+    const regex = /[ _/-]/;
     return title
       .split(regex)
       .map((part) => part[0])
@@ -193,9 +204,13 @@ export default class Entity {
     if(this.display == "state" || this.display == "attribute") {
       if(this.title != this._currentTitle) {
         Logger.debug("[Entity] updating marker for " + this.id + " from " + this._currentTitle + " to " + this.title);
+        // When recreating marker, we need to track if it was in a cluster
+        const wasInCluster = clusterGroup && clusterGroup.hasLayer(this.marker);
         this.marker.remove();
         this.marker = this.createMapMarker();
-        if (clusterGroup) {
+        if (wasInCluster) {
+          clusterGroup.addLayer(this.marker);
+        } else if (clusterGroup) {
           clusterGroup.addLayer(this.marker);
         } else {
           this.marker.addTo(this.map);
@@ -203,7 +218,15 @@ export default class Entity {
         this._currentTitle = this.title;
       }
     }
-    this.marker.setLatLng(this.latLng);
+
+    // Update position only if it has changed significantly (configurable threshold in meters)
+    const newLatLng = this.latLng;
+    const threshold = this.config.positionUpdateThreshold;
+    if (!this._lastSetLatLng || this.map.distance(this._lastSetLatLng, newLatLng) > threshold) {
+      this.marker.setLatLng(newLatLng);
+      this._lastSetLatLng = newLatLng;
+    }
+
     this.historyManager.update();
     this.circle.update();
   }

--- a/src/services/HaLinkedEntityService.js
+++ b/src/services/HaLinkedEntityService.js
@@ -21,6 +21,9 @@ export default class HaLinkedEntityService {
     // Skip if already connected
     if (this.connections[entity]) return;
 
+    // Setup listeners array for entity before subscribing
+    if(!this.listeners[entity]) this.listeners[entity] = [];
+
     Logger.debug(`[HaLinkedEntityService] initializing connection for ${entity}`);
     const connection  = this.hass.connection.subscribeMessage(
         (message) => {
@@ -36,9 +39,11 @@ export default class HaLinkedEntityService {
             Logger.debug(`[HaLinkedEntityService] ${entity} state updated to ${state}`);
 
             // Hit callback for all listeners listing to entities changes
-            this.listeners[entity].forEach(function(callback) { 
-              callback(state)
-            }); 
+            if (this.listeners[entity] && this.listeners[entity].length > 0) {
+              this.listeners[entity].forEach(function(callback) {
+                callback(state)
+              });
+            } 
           }
         },
         {

--- a/src/services/render/EntitiesRenderService.js
+++ b/src/services/render/EntitiesRenderService.js
@@ -1,4 +1,5 @@
 import {Map, LayerGroup, LatLngBounds} from "leaflet";
+import "leaflet.markercluster";
 import EntityConfig from "../../configs/EntityConfig";
 import Entity from "../../models/Entity";
 import Logger from "../../util/Logger";
@@ -29,8 +30,12 @@ export default class EntitiesRenderService {
   historyService;
   /** @type {FocusFollowConfig} */
   focusFollowConfig;
+  /** @type {L.MarkerClusterGroup} */
+  markerClusterGroup;
+  /** @type {boolean} */
+  clusterMarkers;
 
-  constructor(map, hass, focusFollowConfig, entityConfigs, linkedEntityService, dateRangeManager, historyService, isDarkMode) {
+  constructor(map, hass, focusFollowConfig, entityConfigs, linkedEntityService, dateRangeManager, historyService, isDarkMode, clusterMarkers = true) {
     this.map = map;
     this.hass = hass;
     this.focusFollowConfig = focusFollowConfig;
@@ -39,15 +44,27 @@ export default class EntitiesRenderService {
     this.dateRangeManager = dateRangeManager;
     this.historyService = historyService;
     this.isDarkMode = isDarkMode;
+    this.clusterMarkers = clusterMarkers;
   }
 
   setup() {
+    // Initialize marker cluster group if clustering is enabled
+    Logger.debug("[EntitiesRenderService] Clustering enabled: " + this.clusterMarkers);
+    if (this.clusterMarkers) {
+      this.markerClusterGroup = L.markerClusterGroup({
+        showCoverageOnHover: false,
+        removeOutsideVisibleBounds: false,
+      });
+      this.map.addLayer(this.markerClusterGroup);
+      Logger.debug("[EntitiesRenderService] Marker cluster group created and added to map");
+    }
+
     this.entities = this.entityConfigs.map((configEntity) => {
       // Attempt to setup entity. Skip on fail, so one bad entity does not affect others.
       try {
         const entity = new Entity(configEntity, this.hass, this.map, this.historyService, this.dateRangeManager, this.linkedEntityService, this.isDarkMode);
-        entity.setup();
-        return entity; 
+        entity.setup(this.markerClusterGroup);
+        return entity;
       } catch (e){
         Logger.error("Entity: " + configEntity.id + " skipped due to missing data", e);
         HaMapUtilities.renderWarningOnMap(this.map, "Entity: " + configEntity.id + " could not be loaded. See console for details.");
@@ -61,9 +78,44 @@ export default class EntitiesRenderService {
 
   async render() {
     this.entities.forEach((ent) => {
-      ent.update();
+      ent.update(this.markerClusterGroup);
     });
     this.updateInitialView();
+  }
+
+  toggleClustering() {
+    this.clusterMarkers = !this.clusterMarkers;
+
+    if (this.clusterMarkers) {
+      // Enable clustering
+      this.markerClusterGroup = L.markerClusterGroup({
+        showCoverageOnHover: false,
+        removeOutsideVisibleBounds: false,
+      });
+      this.map.addLayer(this.markerClusterGroup);
+
+      // Move all markers to cluster group
+      this.entities.forEach((entity) => {
+        if (entity.marker && this.map.hasLayer(entity.marker)) {
+          this.map.removeLayer(entity.marker);
+          this.markerClusterGroup.addLayer(entity.marker);
+        }
+      });
+    } else {
+      // Disable clustering
+      if (this.markerClusterGroup) {
+        this.markerClusterGroup.clearLayers();
+        this.map.removeLayer(this.markerClusterGroup);
+        this.markerClusterGroup = null;
+      }
+
+      // Add all markers directly to map
+      this.entities.forEach((entity) => {
+        if (entity.marker && !this.map.hasLayer(entity.marker)) {
+          entity.marker.addTo(this.map);
+        }
+      });
+    }
   }
 
   updateInitialView() {


### PR DESCRIPTION
## Summary
Implements entity marker clustering based on Home Assistant frontend PR #24244, along with custom label support and position update threshold to improve the user experience.

### Features Added

**Marker Clustering**
- Automatically groups nearby entity markers using leaflet.markercluster library
- Toggle button UI with group icon to enable/disable clustering dynamically
- Configuration option `cluster_markers` (default: true)

**Custom Labels**
- New `label` configuration option to set custom text on markers
- Overrides auto-generated initials from entity names
- Picture label overlays with semi-transparent background for better visibility

**Position Update Threshold**
- New `position_update_threshold` configuration (default: 10 meters)
- Prevents marker position updates from minor GPS variations
- Reduces cluster re-forming when entities have small position changes
- Configurable per entity

### Bug Fixes
- Fixed race condition in HaLinkedEntityService that caused forEach undefined errors when multiple entities share the same history entity
- Improved marker position update logic to work smoothly with clustering

### Configuration Examples

Basic clustering:
```yaml
type: custom:map-card
cluster_markers: true
entities:
  - device_tracker.phone1
  - device_tracker.phone2
```

Custom labels with pictures:
```yaml
entities:
  - entity: device_tracker.phone
    label: "John"
    picture: /local/john.jpg
    position_update_threshold: 15
```

### Documentation
- Updated README with all new configuration options
- Added descriptions for cluster_markers, label, and position_update_threshold

Fixes #137

Co-Authored-By: Claude <noreply@anthropic.com>