### PR TITLE
feat: Add direct support for GeoJSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ geojson:
   weight: 3
   opacity: 1.0
   fill_opacity: 0.2
+  hide_marker: false
 ```
 
 | name           | Default        | note                                                                                         |
@@ -181,6 +182,7 @@ geojson:
 | `weight`       | 3              | Line weight for GeoJSON features                                                             |
 | `opacity`      | 1.0            | Opacity of lines                                                                             |
 | `fill_opacity` | 0.2            | Opacity of filled areas                                                                      |
+| `hide_marker`  | false          | When set to `true`, hides the default entity marker and only displays the GeoJSON           |
 
 **Supported GeoJSON types:**
 - Point, MultiPoint
@@ -197,6 +199,7 @@ entities:
       attribute: zone_data
       color: '#3388ff'
       fill_opacity: 0.3
+      hide_marker: true
 ```
 
 The GeoJSON data in the entity attribute can be either:

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Either the name of the `entity` or:
 | `z_index_offset`       | 1                                     | z-index value that determines what is displayed on top when markers overlap. (Setting a gap of at least 20 between the values assigned to each entity is recommended.) |
 | `use_base_entity_only` | false                                 | When set to `true`, the tracking will use only the base entity without including any associated device trackers. This is useful for scenarios where you want to track the base entity directly and ignore any associated trackers. |
 | `circle`               |                                       | Display a circle around the marker. <br/>More details [Circle options](#circle-options) |
+| `geojson`              |                                       | Display GeoJSON data from an entity attribute. <br/>More details [GeoJSON options](#geojson-options) |
 
 ### History options
 
@@ -146,6 +147,63 @@ Source
 * `radius` - Will use the `radius` attribute from the entity.
 * `config` - Will use the `radius` set in the config.
 * `attribute` - Will use the `attribute` set in the config.
+
+### GeoJSON options
+
+Display GeoJSON data from an entity attribute. This is useful for displaying zones, areas, routes, or any geographic data stored as GeoJSON in your Home Assistant entities.
+
+The `geojson` option can be configured in several ways:
+
+**Simple usage (uses default attribute name `geo_location`):**
+```yaml
+geojson: true
+```
+
+**Specify a custom attribute name:**
+```yaml
+geojson: zone_geojson
+```
+
+**Full configuration:**
+```yaml
+geojson:
+  attribute: zone_geojson
+  color: '#FF5733'
+  weight: 3
+  opacity: 1.0
+  fill_opacity: 0.2
+```
+
+| name           | Default        | note                                                                                         |
+|----------------|----------------|----------------------------------------------------------------------------------------------|
+| `attribute`    | `geo_location` | The entity attribute containing the GeoJSON data                                             |
+| `color`        | Entity color   | Color for the GeoJSON features (lines and fills)                                             |
+| `weight`       | 3              | Line weight for GeoJSON features                                                             |
+| `opacity`      | 1.0            | Opacity of lines                                                                             |
+| `fill_opacity` | 0.2            | Opacity of filled areas                                                                      |
+
+**Supported GeoJSON types:**
+- Point, MultiPoint
+- LineString, MultiLineString
+- Polygon, MultiPolygon
+- GeometryCollection
+- Feature, FeatureCollection
+
+**Example entity configuration:**
+```yaml
+entities:
+  - entity: sensor.my_zone
+    geojson:
+      attribute: zone_data
+      color: '#3388ff'
+      fill_opacity: 0.3
+```
+
+The GeoJSON data in the entity attribute can be either:
+- A JSON string: `'{"type": "Polygon", "coordinates": [[[0,0], [1,0], [1,1], [0,1], [0,0]]]}'`
+- A parsed JSON object (if your integration provides it that way)
+
+If the GeoJSON Feature or FeatureCollection includes properties, they will be displayed in tooltips when hovering over the features.
 
 ### WMS and tile_layers options
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,9 @@ The GeoJSON data in the entity attribute can be either:
 - A JSON string: `'{"type": "Polygon", "coordinates": [[[0,0], [1,0], [1,1], [0,1], [0,0]]]}'`
 - A parsed JSON object (if your integration provides it that way)
 
-If the GeoJSON Feature or FeatureCollection includes properties, they will be displayed in tooltips when hovering over the features.
+**Interactive Features:**
+- GeoJSON zones are **clickable** - clicking on any GeoJSON feature will show the entity's more-info dialog (or trigger the configured `tap_action`)
+- If the GeoJSON Feature or FeatureCollection includes properties, they will be displayed in tooltips when hovering over the features
 
 ### WMS and tile_layers options
 

--- a/src/configs/EntityConfig.js
+++ b/src/configs/EntityConfig.js
@@ -1,6 +1,7 @@
 import HaMapUtilities from "../util/HaMapUtilities.js"
 import Logger from "../util/Logger.js";
 import CircleConfig from "./CircleConfig.js";
+import GeoJsonConfig from "./GeoJsonConfig.js";
 
 export default class EntityConfig {
   /** @type {string} */
@@ -45,7 +46,7 @@ export default class EntityConfig {
   css;
   // Cannot be set via config. Passed from parent
   historyManagedExternally;
-  
+
   /** @type {string} */
   picture;
   /** @type {string} */
@@ -62,12 +63,15 @@ export default class EntityConfig {
   zIndexOffset;
   /** @type {boolean} */
   useBaseEntityOnly;
-  
+
   /** @type {CircleConfig} */
   circleConfig;
 
+  /** @type {GeoJsonConfig} */
+  geoJsonConfig;
+
   constructor(config, defaults) {
-    this.id = (typeof config === 'string' || config instanceof String)? config : config.entity;
+    this.id = (typeof config === 'string' || config instanceof String) ? config : config.entity;
     this.display = config.display ? config.display : "marker";
     this.attribute = config.attribute ? config.attribute : "";
     this.prefix = config.display === "attribute" ? (config.prefix ? config.prefix : "") : "";
@@ -76,7 +80,7 @@ export default class EntityConfig {
     // If historyLineColor not set, inherit icon color
     this.color = config.color ?? this._generateRandomColor();
     this.gradualOpacity = config.gradual_opacity ? config.gradual_opacity : undefined;
-    
+
     // Get history value to use (normal of default)
     const historyStart = config.history_start ?? defaults.historyStart;
     const historyEnd = config.history_end ?? defaults.historyEnd;
@@ -86,7 +90,7 @@ export default class EntityConfig {
       this.historyStartEntity = historyStart['entity'] ?? historyStart;
       this.historyStartEntitySuffix = historyStart['suffix'];
     } else {
-        this.historyStart = historyStart ? HaMapUtilities.convertToAbsoluteDate(historyStart) : null;
+      this.historyStart = historyStart ? HaMapUtilities.convertToAbsoluteDate(historyStart) : null;
     }
 
     // If end is an entity, setup entity config
@@ -112,7 +116,7 @@ export default class EntityConfig {
     this.usingDateRangeManager = (!historyStart && !historyEnd) && defaults.dateRangeManagerEnabled;
 
     // Tap action defaults to standard more-info.
-    this.tapAction = (typeof config.tap_action == 'object') ? this.parseAction(config.tap_action) : {action: 'more-info'};
+    this.tapAction = (typeof config.tap_action == 'object') ? this.parseAction(config.tap_action) : { action: 'more-info' };
 
     this.focusOnFit = config.focus_on_fit ?? true;
     this.zIndexOffset = config.z_index_offset ? config.z_index_offset : 1;
@@ -120,14 +124,14 @@ export default class EntityConfig {
     this.useBaseEntityOnly = config.use_base_entity_only ?? false;
 
     this.circleConfig = new CircleConfig(config.circle, this.color);
+    this.geoJsonConfig = new GeoJsonConfig(config.geojson, this.color);
     Logger.debug(
-      `[EntityConfig]: created with id: ${this.id}, display: ${this.display}, attribute: ${this.attribute}, prefix: ${this.prefix}, suffix: ${this.suffix}, size: ${this.size}, historyStart: ${this.historyStart}, historyEnd: ${this.historyEnd}, historyStartEntity: ${this.historyStartEntity}, historyEndEntity: ${this.historyEndEntity}, historyLineColor: ${this.historyLineColor}, historyShowDots: ${this.historyShowDots}, historyShowLines: ${this.historyShowLines}, fixedX: ${this.fixedX}, fixedY: ${this.fixedY}, fallbackX: ${this.fallbackX}, fallbackY: ${this.fallbackY}, css: ${this.css}, picture: ${this.picture}, icon: ${this.icon}, color: ${this.color}, gradualOpacity: ${this.gradualOpacity}, tapAction: ${this.tapAction}, focusOnFit: ${this.focusOnFit}, zIndexOffset: ${this.zIndexOffset}, useBaseEntityOnly: ${this.useBaseEntityOnly}, circleConfig: ${this.circleConfig}`
+      `[EntityConfig]: created with id: ${this.id}, display: ${this.display}, attribute: ${this.attribute}, prefix: ${this.prefix}, suffix: ${this.suffix}, size: ${this.size}, historyStart: ${this.historyStart}, historyEnd: ${this.historyEnd}, historyStartEntity: ${this.historyStartEntity}, historyEndEntity: ${this.historyEndEntity}, historyLineColor: ${this.historyLineColor}, historyShowDots: ${this.historyShowDots}, historyShowLines: ${this.historyShowLines}, fixedX: ${this.fixedX}, fixedY: ${this.fixedY}, fallbackX: ${this.fallbackX}, fallbackY: ${this.fallbackY}, css: ${this.css}, picture: ${this.picture}, icon: ${this.icon}, color: ${this.color}, gradualOpacity: ${this.gradualOpacity}, tapAction: ${this.tapAction}, focusOnFit: ${this.focusOnFit}, zIndexOffset: ${this.zIndexOffset}, useBaseEntityOnly: ${this.useBaseEntityOnly}, circleConfig: ${this.circleConfig}, geoJsonConfig: ${this.geoJsonConfig}`
     );
   }
 
   // Get tap action_data
-  parseAction(tap_action)
-  {
+  parseAction(tap_action) {
     // No additional props
     if (['more-info', 'none'].includes(tap_action.action)) {
       return {
@@ -137,7 +141,7 @@ export default class EntityConfig {
 
     if (tap_action.action == 'navigate') {
       // Validate
-      if(!tap_action.navigation_path) throw new Error("'navigation_path' is required when using action 'navigate'");
+      if (!tap_action.navigation_path) throw new Error("'navigation_path' is required when using action 'navigate'");
 
       return {
         action: tap_action.action,
@@ -146,11 +150,11 @@ export default class EntityConfig {
     }
     if (tap_action.action == 'url') {
       // Validate
-      if(!tap_action.url_path) throw new Error("'url_path' is required when using action 'url'");
+      if (!tap_action.url_path) throw new Error("'url_path' is required when using action 'url'");
 
       return {
         action: tap_action.action,
-        url_path: tap_action.url_path 
+        url_path: tap_action.url_path
       };
     }
 
@@ -158,10 +162,10 @@ export default class EntityConfig {
       // Validate
       if (!tap_action.service) throw new Error("'service' is required when using action 'call-service'");
       return {
-        action:   tap_action.action,
-        service:  tap_action.service,
+        action: tap_action.action,
+        service: tap_action.service,
         // I belive this is truely optional.
-        data:     tap_action.data   
+        data: tap_action.data
       };
     }
 
@@ -170,26 +174,26 @@ export default class EntityConfig {
 
   get hasHistory() {
     return this.historyStart != null || this.historyStartEntity != null || this.usingDateRangeManager === true;
-  }  
+  }
 
   _generateRandomColor() {
     // Generate pseudo-random color from provided entity id
     let str = this.id;
-    
+
     // Generate a BigInt numeric hash of the string provided.
     // 53-bit hash based on cyrb53 (c) 2018 bryc (github.com/bryc). 
     // License: Public domain, https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js
     let h1 = 0xdeadbeef, h2 = 0x41c6ce57;
-    for(let i = 0, ch; i < str.length; i++) {
+    for (let i = 0, ch; i < str.length; i++) {
       ch = str.charCodeAt(i);
       h1 = Math.imul(h1 ^ ch, 2654435761);
       h2 = Math.imul(h2 ^ ch, 1597334677);
     }
-    h1  = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+    h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
     h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
-    h2  = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+    h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
     h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
-    let hash =  4294967296 * (2097151 & h2) + (h1 >>> 0);
+    let hash = 4294967296 * (2097151 & h2) + (h1 >>> 0);
 
     // Now that we have a numeric hash, construct a CSS hsl() color with hue derived from the hash above (hash % 360), 95% saturation and 35% lightness.
     // Unlike the simplified RGB approach (#RRGGBB) this method produces colors with similar saturation and lightness, resulting in a more aesthetically pleasing palette.

--- a/src/configs/GeoJsonConfig.js
+++ b/src/configs/GeoJsonConfig.js
@@ -1,0 +1,55 @@
+import Logger from "../util/Logger.js";
+
+export default class GeoJsonConfig {
+  /** @type {boolean} */
+  enabled;
+  /** @type {string} */
+  attribute;
+  /** @type {string} */
+  color;
+  /** @type {number} */
+  weight;
+  /** @type {number} */
+  opacity;
+  /** @type {number} */
+  fillOpacity;
+
+  /**
+   * @param {object|string|boolean} config 
+   * @param {string} defaultColor 
+   */
+  constructor(config, defaultColor) {
+    // Handle disabled case
+    if (config === false || config === null || config === undefined) {
+      this.enabled = false;
+      return;
+    }
+
+    // Handle simple string case (just attribute name)
+    if (typeof config === 'string') {
+      this.enabled = true;
+      this.attribute = config;
+      this.color = defaultColor;
+      this.weight = 3;
+      this.opacity = 1.0;
+      this.fillOpacity = 0.2;
+      return;
+    }
+
+    // Handle object configuration
+    if (typeof config === 'object') {
+      this.enabled = true;
+      this.attribute = config.attribute || 'geo_location';
+      this.color = config.color || defaultColor;
+      this.weight = config.weight !== undefined ? config.weight : 3;
+      this.opacity = config.opacity !== undefined ? config.opacity : 1.0;
+      this.fillOpacity = config.fill_opacity !== undefined ? config.fill_opacity : 0.2;
+    } else {
+      this.enabled = false;
+    }
+
+    Logger.debug(
+      `[GeoJsonConfig]: created with enabled: ${this.enabled}, attribute: ${this.attribute}, color: ${this.color}, weight: ${this.weight}, opacity: ${this.opacity}, fillOpacity: ${this.fillOpacity}`
+    );
+  }
+}

--- a/src/configs/GeoJsonConfig.js
+++ b/src/configs/GeoJsonConfig.js
@@ -13,6 +13,8 @@ export default class GeoJsonConfig {
   opacity;
   /** @type {number} */
   fillOpacity;
+  /** @type {boolean} */
+  hideMarker;
 
   /**
    * @param {object|string|boolean} config 
@@ -33,6 +35,7 @@ export default class GeoJsonConfig {
       this.weight = 3;
       this.opacity = 1.0;
       this.fillOpacity = 0.2;
+      this.hideMarker = false;
       return;
     }
 
@@ -44,12 +47,13 @@ export default class GeoJsonConfig {
       this.weight = config.weight !== undefined ? config.weight : 3;
       this.opacity = config.opacity !== undefined ? config.opacity : 1.0;
       this.fillOpacity = config.fill_opacity !== undefined ? config.fill_opacity : 0.2;
+      this.hideMarker = config.hide_marker !== undefined ? config.hide_marker : false;
     } else {
       this.enabled = false;
     }
 
     Logger.debug(
-      `[GeoJsonConfig]: created with enabled: ${this.enabled}, attribute: ${this.attribute}, color: ${this.color}, weight: ${this.weight}, opacity: ${this.opacity}, fillOpacity: ${this.fillOpacity}`
+      `[GeoJsonConfig]: created with enabled: ${this.enabled}, attribute: ${this.attribute}, color: ${this.color}, weight: ${this.weight}, opacity: ${this.opacity}, fillOpacity: ${this.fillOpacity}, hideMarker: ${this.hideMarker}`
     );
   }
 }

--- a/src/configs/GeoJsonConfig.test.js
+++ b/src/configs/GeoJsonConfig.test.js
@@ -1,0 +1,83 @@
+import GeoJsonConfig from './GeoJsonConfig';
+
+describe('GeoJsonConfig', () => {
+  describe('constructor', () => {
+    it('should create disabled config when passed false', () => {
+      const config = new GeoJsonConfig(false, '#ff0000');
+      expect(config.enabled).toBe(false);
+    });
+
+    it('should create disabled config when passed null', () => {
+      const config = new GeoJsonConfig(null, '#ff0000');
+      expect(config.enabled).toBe(false);
+    });
+
+    it('should create disabled config when passed undefined', () => {
+      const config = new GeoJsonConfig(undefined, '#ff0000');
+      expect(config.enabled).toBe(false);
+    });
+
+    it('should create config with string attribute name', () => {
+      const config = new GeoJsonConfig('zone_data', '#ff0000');
+      expect(config.enabled).toBe(true);
+      expect(config.attribute).toBe('zone_data');
+      expect(config.color).toBe('#ff0000');
+      expect(config.weight).toBe(3);
+      expect(config.opacity).toBe(1.0);
+      expect(config.fillOpacity).toBe(0.2);
+    });
+
+    it('should create config with object configuration', () => {
+      const config = new GeoJsonConfig(
+        {
+          attribute: 'custom_geo',
+          color: '#00ff00',
+          weight: 5,
+          opacity: 0.8,
+          fill_opacity: 0.5
+        },
+        '#ff0000'
+      );
+      expect(config.enabled).toBe(true);
+      expect(config.attribute).toBe('custom_geo');
+      expect(config.color).toBe('#00ff00');
+      expect(config.weight).toBe(5);
+      expect(config.opacity).toBe(0.8);
+      expect(config.fillOpacity).toBe(0.5);
+    });
+
+    it('should use default attribute name when not specified in object', () => {
+      const config = new GeoJsonConfig({}, '#ff0000');
+      expect(config.enabled).toBe(true);
+      expect(config.attribute).toBe('geo_location');
+    });
+
+    it('should use default color when not specified in object', () => {
+      const config = new GeoJsonConfig({ attribute: 'test' }, '#ff0000');
+      expect(config.enabled).toBe(true);
+      expect(config.color).toBe('#ff0000');
+    });
+
+    it('should use default values for optional properties', () => {
+      const config = new GeoJsonConfig({ attribute: 'test' }, '#ff0000');
+      expect(config.weight).toBe(3);
+      expect(config.opacity).toBe(1.0);
+      expect(config.fillOpacity).toBe(0.2);
+    });
+
+    it('should handle zero values for numeric properties', () => {
+      const config = new GeoJsonConfig(
+        {
+          attribute: 'test',
+          weight: 0,
+          opacity: 0,
+          fill_opacity: 0
+        },
+        '#ff0000'
+      );
+      expect(config.weight).toBe(0);
+      expect(config.opacity).toBe(0);
+      expect(config.fillOpacity).toBe(0);
+    });
+  });
+});

--- a/src/configs/GeoJsonConfig.test.js
+++ b/src/configs/GeoJsonConfig.test.js
@@ -25,6 +25,7 @@ describe('GeoJsonConfig', () => {
       expect(config.weight).toBe(3);
       expect(config.opacity).toBe(1.0);
       expect(config.fillOpacity).toBe(0.2);
+      expect(config.hideMarker).toBe(false);
     });
 
     it('should create config with object configuration', () => {
@@ -44,6 +45,7 @@ describe('GeoJsonConfig', () => {
       expect(config.weight).toBe(5);
       expect(config.opacity).toBe(0.8);
       expect(config.fillOpacity).toBe(0.5);
+      expect(config.hideMarker).toBe(false);
     });
 
     it('should use default attribute name when not specified in object', () => {
@@ -78,6 +80,38 @@ describe('GeoJsonConfig', () => {
       expect(config.weight).toBe(0);
       expect(config.opacity).toBe(0);
       expect(config.fillOpacity).toBe(0);
+    });
+
+    it('should set hideMarker to true when specified', () => {
+      const config = new GeoJsonConfig(
+        {
+          attribute: 'test',
+          hide_marker: true
+        },
+        '#ff0000'
+      );
+      expect(config.hideMarker).toBe(true);
+    });
+
+    it('should set hideMarker to false when explicitly set to false', () => {
+      const config = new GeoJsonConfig(
+        {
+          attribute: 'test',
+          hide_marker: false
+        },
+        '#ff0000'
+      );
+      expect(config.hideMarker).toBe(false);
+    });
+
+    it('should default hideMarker to false when not specified', () => {
+      const config = new GeoJsonConfig(
+        {
+          attribute: 'test'
+        },
+        '#ff0000'
+      );
+      expect(config.hideMarker).toBe(false);
     });
   });
 });

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -1,6 +1,7 @@
 
 import { DivIcon, LatLng, Map, Marker } from "leaflet";
 import Circle from "./Circle.js";
+import GeoJson from "./GeoJson.js";
 import Logger from "../util/Logger.js"
 import EntityConfig from "../configs/EntityConfig.js";
 import EntityHistoryManager from "./EntityHistoryManager.js";
@@ -34,14 +35,19 @@ export default class Entity {
    * @type {boolean} 
    */
   darkMode;
-  /** 
+  /**
    * @private
-   * @type {Circle} 
+   * @type {Circle}
    */
   circle;
-  /** 
-   * @private 
-   * @type {EntityHistoryManager} 
+  /**
+   * @private
+   * @type {GeoJson}
+   */
+  geoJson;
+  /**
+   * @private
+   * @type {EntityHistoryManager}
    */
   historyManager;
   /** 
@@ -53,7 +59,7 @@ export default class Entity {
    * @private
    * @type {LatLng} 
    */
-  _currentLatLng;  
+  _currentLatLng;
 
   constructor(config, hass, map, historyService, dateRangeManager, linkedEntityService, darkMode) {
     this.config = config;
@@ -61,10 +67,11 @@ export default class Entity {
     this.map = map;
     this.darkMode = darkMode;
 
-    if(this.display == "state" || this.display == "attribute") {
+    if (this.display == "state" || this.display == "attribute") {
       this._currentTitle = this.title;
     }
     this.circle = new Circle(this.config.circleConfig, this);
+    this.geoJson = new GeoJson(this.config.geoJsonConfig, this);
     this.historyManager = new EntityHistoryManager(this, historyService, dateRangeManager, linkedEntityService);
   }
 
@@ -100,34 +107,34 @@ export default class Entity {
   }
 
   /** @returns {LatLng} */
-  get latLng() {    
-    if(this.config.fixedX && this.config.fixedY) {
+  get latLng() {
+    if (this.config.fixedX && this.config.fixedY) {
       return new LatLng(this.config.fixedX, this.config.fixedY);
     }
-    
-    if(this._currentLatLng) {
+
+    if (this._currentLatLng) {
       return this._currentLatLng;
     }
-    
+
     // Do we have Lng/Lat directly?
     if (this.attributes.latitude && this.attributes.longitude) {
       return new LatLng(this.attributes.latitude, this.attributes.longitude);
     }
-    
+
     // Get Lat/Lng of entity. Some entities such as "person" define device_trackers allowing
     // multiple lat/lng sources to be used. This method will call down through these looking for a
     // lat/lng value if none is defined on the parent entity.
     // If any, see if we can get a lng/lat from one instead
     let subTrackerIds = this.attributes.device_trackers ?? []
-    for(let t=0; t<subTrackerIds.length; t++) {
+    for (let t = 0; t < subTrackerIds.length; t++) {
       const entity = this.hass.states[subTrackerIds[t]];
       if (entity.attributes.latitude && entity.attributes.longitude) {
         return new LatLng(entity.attributes.latitude, entity.attributes.longitude);
       }
-    }    
-    
+    }
+
     Logger.warn("Entity: " + this.id + " has no latitude & longitude");
-    if(this.config.fallbackX && this.config.fallbackY) {
+    if (this.config.fallbackX && this.config.fallbackY) {
       return new LatLng(this.config.fallbackX, this.config.fallbackY);
     }
     Logger.error("Entity: " + this.id + " has no fallback latitude & longitude");
@@ -139,14 +146,15 @@ export default class Entity {
     this.marker.addTo(this.map);
     this.historyManager.setup();
     this.circle.setup();
+    this.geoJson.setup();
   }
 
-  /** @param {TimelineEntry} entry */  
-  react(entry) {    
+  /** @param {TimelineEntry} entry */
+  react(entry) {
     if (entry.entityId == this.id) {
       this.currentTimelineEntry = entry;
     }
-    this._currentLatLng = new LatLng(entry.latitude, entry.longitude);    
+    this._currentLatLng = new LatLng(entry.latitude, entry.longitude);
   }
 
   get friendlyName() {
@@ -155,17 +163,17 @@ export default class Entity {
 
   /** @returns {string} */
   get title() {
-    if(this.display == "state") {
+    if (this.display == "state") {
       return this.state;
     }
-    if(this.display == "attribute") {
+    if (this.display == "attribute") {
       return this.hass.formatEntityAttributeValue(this.hass.states[this.id], this.config.attribute);
     }
     const title = this.friendlyName;
-    if(title.length < 5) {
+    if (title.length < 5) {
       return title;
     }
-    const regex = /[ _/-]/; 
+    const regex = /[ _/-]/;
     return title
       .split(regex)
       .map((part) => part[0])
@@ -181,11 +189,11 @@ export default class Entity {
 
   get icon() {
     return this.config.icon ?? this.attributes.icon;
-  }  
+  }
 
   async update() {
-    if(this.display == "state" || this.display == "attribute") {
-      if(this.title != this._currentTitle) {
+    if (this.display == "state" || this.display == "attribute") {
+      if (this.title != this._currentTitle) {
         Logger.debug("[Entity] updating marker for " + this.id + " from " + this._currentTitle + " to " + this.title);
         this.marker.remove();
         this.marker = this.createMapMarker();
@@ -196,6 +204,7 @@ export default class Entity {
     this.marker.setLatLng(this.latLng);
     this.historyManager.update();
     this.circle.update();
+    this.geoJson.update();
   }
 
   /**
@@ -206,10 +215,10 @@ export default class Entity {
     Logger.debug("[MarkerEntity] Creating marker for " + this.id + " with display mode " + this.display);
     let icon = this.icon;
     let picture = this.picture;
-    if(this.display == "icon") {
+    if (this.display == "icon") {
       picture = null;
     }
-    if(this.display == "state" || this.display == "attribute") {
+    if (this.display == "state" || this.display == "attribute") {
       picture = null;
       icon = null;
     }

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -142,8 +142,11 @@ export default class Entity {
   }
 
   setup() {
-    this.marker = this.createMapMarker();
-    this.marker.addTo(this.map);
+    // Only add marker if GeoJSON is not configured to hide it
+    if (!this.config.geoJsonConfig.hideMarker) {
+      this.marker = this.createMapMarker();
+      this.marker.addTo(this.map);
+    }
     this.historyManager.setup();
     this.circle.setup();
     this.geoJson.setup();
@@ -192,16 +195,19 @@ export default class Entity {
   }
 
   async update() {
-    if (this.display == "state" || this.display == "attribute") {
-      if (this.title != this._currentTitle) {
-        Logger.debug("[Entity] updating marker for " + this.id + " from " + this._currentTitle + " to " + this.title);
-        this.marker.remove();
-        this.marker = this.createMapMarker();
-        this.marker.addTo(this.map);
-        this._currentTitle = this.title;
+    // Only update marker if it exists (not hidden by GeoJSON config)
+    if (this.marker) {
+      if (this.display == "state" || this.display == "attribute") {
+        if (this.title != this._currentTitle) {
+          Logger.debug("[Entity] updating marker for " + this.id + " from " + this._currentTitle + " to " + this.title);
+          this.marker.remove();
+          this.marker = this.createMapMarker();
+          this.marker.addTo(this.map);
+          this._currentTitle = this.title;
+        }
       }
+      this.marker.setLatLng(this.latLng);
     }
-    this.marker.setLatLng(this.latLng);
     this.historyManager.update();
     this.circle.update();
     this.geoJson.update();

--- a/src/models/GeoJson.js
+++ b/src/models/GeoJson.js
@@ -1,0 +1,141 @@
+import L from "leaflet";
+import Logger from "../util/Logger.js";
+import GeoJsonConfig from "../configs/GeoJsonConfig.js";
+
+export default class GeoJson {
+  /** @type {GeoJsonConfig} */
+  config;
+  /** @type {Entity} */
+  entity;
+  /** @type {L.GeoJSON} */
+  geoJsonLayer;
+
+  /**
+   * @param {GeoJsonConfig} config 
+   * @param {Entity} entity 
+   */
+  constructor(config, entity) {
+    this.config = config;
+    this.entity = entity;
+  }
+
+  setup() {
+    if (!this.config.enabled) {
+      return;
+    }
+
+    try {
+      const geoJsonData = this._getGeoJsonData();
+      if (geoJsonData) {
+        this._renderGeoJson(geoJsonData);
+      }
+    } catch (e) {
+      Logger.error(`[GeoJson]: Failed to setup GeoJSON for ${this.entity.id}`, e);
+    }
+  }
+
+  update() {
+    if (!this.config.enabled) {
+      return;
+    }
+
+    try {
+      // Remove existing layer
+      if (this.geoJsonLayer) {
+        this.entity.map.removeLayer(this.geoJsonLayer);
+        this.geoJsonLayer = null;
+      }
+
+      // Re-render with updated data
+      const geoJsonData = this._getGeoJsonData();
+      if (geoJsonData) {
+        this._renderGeoJson(geoJsonData);
+      }
+    } catch (e) {
+      Logger.error(`[GeoJson]: Failed to update GeoJSON for ${this.entity.id}`, e);
+    }
+  }
+
+  /**
+   * @private
+   * @returns {object|null}
+   */
+  _getGeoJsonData() {
+    const attributeValue = this.entity.attributes[this.config.attribute];
+
+    if (!attributeValue) {
+      Logger.debug(`[GeoJson]: No data found in attribute '${this.config.attribute}' for ${this.entity.id}`);
+      return null;
+    }
+
+    // If it's a string, try to parse it as JSON
+    if (typeof attributeValue === 'string') {
+      try {
+        return JSON.parse(attributeValue);
+      } catch (e) {
+        Logger.error(`[GeoJson]: Failed to parse GeoJSON string from attribute '${this.config.attribute}' for ${this.entity.id}`, e);
+        return null;
+      }
+    }
+
+    // If it's already an object, use it directly
+    if (typeof attributeValue === 'object') {
+      return attributeValue;
+    }
+
+    Logger.warn(`[GeoJson]: Attribute '${this.config.attribute}' for ${this.entity.id} is not a valid GeoJSON object or string`);
+    return null;
+  }
+
+  /**
+   * @private
+   * @param {object} geoJsonData 
+   */
+  _renderGeoJson(geoJsonData) {
+    const style = {
+      color: this.config.color,
+      weight: this.config.weight,
+      opacity: this.config.opacity,
+      fillOpacity: this.config.fillOpacity
+    };
+
+    this.geoJsonLayer = L.geoJSON(geoJsonData, {
+      style: () => style,
+      pointToLayer: (feature, latlng) => {
+        // For point features, create a circle marker with the configured style
+        return L.circleMarker(latlng, {
+          radius: 6,
+          ...style,
+          fillOpacity: 0.8
+        });
+      },
+      onEachFeature: (feature, layer) => {
+        // Add tooltip if feature has properties
+        if (feature.properties) {
+          const tooltipContent = this._createTooltipContent(feature.properties);
+          if (tooltipContent) {
+            layer.bindTooltip(tooltipContent, { direction: 'top' });
+          }
+        }
+      }
+    });
+
+    this.geoJsonLayer.addTo(this.entity.map);
+    Logger.debug(`[GeoJson]: Rendered GeoJSON for ${this.entity.id}`);
+  }
+
+  /**
+   * @private
+   * @param {object} properties 
+   * @returns {string}
+   */
+  _createTooltipContent(properties) {
+    // Create a simple tooltip from properties
+    const entries = Object.entries(properties)
+      .filter(([key, value]) => value !== null && value !== undefined)
+      .map(([key, value]) => `${key}: ${value}`)
+      .slice(0, 5); // Limit to first 5 properties
+
+    return entries.length > 0 ? entries.join('<br>') : '';
+  }
+}

--- a/src/models/GeoJson.js
+++ b/src/models/GeoJson.js
@@ -117,6 +117,11 @@ export default class GeoJson {
             layer.bindTooltip(tooltipContent, { direction: 'top' });
           }
         }
+
+        // Make the layer clickable to show entity popup
+        layer.on('click', (e) => {
+          this._handleLayerClick(e);
+        });
       }
     });
 
@@ -126,7 +131,7 @@ export default class GeoJson {
 
   /**
    * @private
-   * @param {object} properties 
+   * @param {object} properties
    * @returns {string}
    */
   _createTooltipContent(properties) {
@@ -137,5 +142,33 @@ export default class GeoJson {
       .slice(0, 5); // Limit to first 5 properties
 
     return entries.length > 0 ? entries.join('<br>') : '';
+  }
+
+  /**
+   * Handle click on GeoJSON layer to show entity popup
+   * @private
+   * @param {L.LeafletMouseEvent} e
+   */
+  _handleLayerClick(e) {
+    // Stop propagation to prevent map click
+    L.DomEvent.stopPropagation(e);
+
+    // Create and dispatch hass-action event to show entity more-info dialog
+    const event = new CustomEvent('hass-action', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        config: {
+          entity: this.entity.id,
+          tap_action: this.entity.config.tapAction
+        },
+        action: 'tap'
+      }
+    });
+
+    // Dispatch from the map container to ensure it bubbles up to Home Assistant
+    this.entity.map.getContainer().dispatchEvent(event);
+
+    Logger.debug(`[GeoJson]: Clicked on GeoJSON for ${this.entity.id}`);
   }
 }

--- a/src/models/GeoJson.test.js
+++ b/src/models/GeoJson.test.js
@@ -1,0 +1,260 @@
+import GeoJson from './GeoJson';
+import GeoJsonConfig from '../configs/GeoJsonConfig';
+import Logger from '../util/Logger';
+import L from 'leaflet';
+
+// Mock Leaflet
+jest.mock('leaflet', () => ({
+  geoJSON: jest.fn(() => ({
+    addTo: jest.fn()
+  })),
+  circleMarker: jest.fn()
+}));
+
+// Mock Logger to suppress expected error messages in tests
+jest.mock('../util/Logger', () => ({
+  debug: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn()
+}));
+
+describe('GeoJson', () => {
+  let mockEntity;
+  let mockMap;
+
+  beforeEach(() => {
+    mockMap = {
+      removeLayer: jest.fn()
+    };
+
+    mockEntity = {
+      id: 'test-entity',
+      map: mockMap,
+      attributes: {}
+    };
+
+    jest.clearAllMocks();
+  });
+
+  describe('setup', () => {
+    it('should not render when config is disabled', () => {
+      const config = new GeoJsonConfig(false, '#ff0000');
+      const geoJson = new GeoJson(config, mockEntity);
+
+      geoJson.setup();
+
+      expect(L.geoJSON).not.toHaveBeenCalled();
+    });
+
+    it('should not render when attribute is missing', () => {
+      const config = new GeoJsonConfig('zone_data', '#ff0000');
+      const geoJson = new GeoJson(config, mockEntity);
+
+      geoJson.setup();
+
+      expect(L.geoJSON).not.toHaveBeenCalled();
+    });
+
+    it('should render GeoJSON from object attribute', () => {
+      const geoJsonData = {
+        type: 'Point',
+        coordinates: [0, 0]
+      };
+
+      mockEntity.attributes = {
+        zone_data: geoJsonData
+      };
+
+      const config = new GeoJsonConfig('zone_data', '#ff0000');
+      const geoJson = new GeoJson(config, mockEntity);
+
+      geoJson.setup();
+
+      expect(L.geoJSON).toHaveBeenCalledWith(
+        geoJsonData,
+        expect.objectContaining({
+          style: expect.any(Function),
+          pointToLayer: expect.any(Function),
+          onEachFeature: expect.any(Function)
+        })
+      );
+    });
+
+    it('should render GeoJSON from string attribute', () => {
+      const geoJsonData = {
+        type: 'Point',
+        coordinates: [0, 0]
+      };
+
+      mockEntity.attributes = {
+        zone_data: JSON.stringify(geoJsonData)
+      };
+
+      const config = new GeoJsonConfig('zone_data', '#ff0000');
+      const geoJson = new GeoJson(config, mockEntity);
+
+      geoJson.setup();
+
+      expect(L.geoJSON).toHaveBeenCalledWith(
+        geoJsonData,
+        expect.any(Object)
+      );
+    });
+
+    it('should handle invalid JSON string gracefully', () => {
+      mockEntity.attributes = {
+        zone_data: 'invalid json'
+      };
+
+      const config = new GeoJsonConfig('zone_data', '#ff0000');
+      const geoJson = new GeoJson(config, mockEntity);
+
+      geoJson.setup();
+
+      expect(L.geoJSON).not.toHaveBeenCalled();
+      expect(Logger.error).toHaveBeenCalled();
+    });
+
+    it('should apply custom style configuration', () => {
+      const geoJsonData = {
+        type: 'Polygon',
+        coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]
+      };
+
+      mockEntity.attributes = {
+        zone_data: geoJsonData
+      };
+
+      const config = new GeoJsonConfig(
+        {
+          attribute: 'zone_data',
+          color: '#00ff00',
+          weight: 5,
+          opacity: 0.8,
+          fill_opacity: 0.5
+        },
+        '#ff0000'
+      );
+      const geoJson = new GeoJson(config, mockEntity);
+
+      geoJson.setup();
+
+      const styleFunction = L.geoJSON.mock.calls[0][1].style;
+      const style = styleFunction();
+
+      expect(style).toEqual({
+        color: '#00ff00',
+        weight: 5,
+        opacity: 0.8,
+        fillOpacity: 0.5
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('should remove old layer and render new one', () => {
+      const geoJsonData = {
+        type: 'Point',
+        coordinates: [0, 0]
+      };
+
+      mockEntity.attributes = {
+        zone_data: geoJsonData
+      };
+
+      const config = new GeoJsonConfig('zone_data', '#ff0000');
+      const geoJson = new GeoJson(config, mockEntity);
+
+      // Setup initial layer
+      geoJson.setup();
+      const initialCallCount = L.geoJSON.mock.calls.length;
+
+      // Update with new data
+      mockEntity.attributes.zone_data = {
+        type: 'Point',
+        coordinates: [1, 1]
+      };
+
+      geoJson.update();
+
+      expect(mockMap.removeLayer).toHaveBeenCalled();
+      expect(L.geoJSON).toHaveBeenCalledTimes(initialCallCount + 1);
+    });
+
+    it('should not render when config is disabled', () => {
+      const config = new GeoJsonConfig(false, '#ff0000');
+      const geoJson = new GeoJson(config, mockEntity);
+
+      geoJson.update();
+
+      expect(L.geoJSON).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('_createTooltipContent', () => {
+    it('should create tooltip from properties', () => {
+      const config = new GeoJsonConfig('zone_data', '#ff0000');
+      const geoJson = new GeoJson(config, mockEntity);
+
+      const properties = {
+        name: 'Test Zone',
+        type: 'residential',
+        population: 1000
+      };
+
+      const tooltip = geoJson._createTooltipContent(properties);
+
+      expect(tooltip).toContain('name: Test Zone');
+      expect(tooltip).toContain('type: residential');
+      expect(tooltip).toContain('population: 1000');
+    });
+
+    it('should filter out null and undefined values', () => {
+      const config = new GeoJsonConfig('zone_data', '#ff0000');
+      const geoJson = new GeoJson(config, mockEntity);
+
+      const properties = {
+        name: 'Test Zone',
+        empty: null,
+        missing: undefined,
+        valid: 'value'
+      };
+
+      const tooltip = geoJson._createTooltipContent(properties);
+
+      expect(tooltip).toContain('name: Test Zone');
+      expect(tooltip).toContain('valid: value');
+      expect(tooltip).not.toContain('empty');
+      expect(tooltip).not.toContain('missing');
+    });
+
+    it('should limit to first 5 properties', () => {
+      const config = new GeoJsonConfig('zone_data', '#ff0000');
+      const geoJson = new GeoJson(config, mockEntity);
+
+      const properties = {
+        prop1: 'value1',
+        prop2: 'value2',
+        prop3: 'value3',
+        prop4: 'value4',
+        prop5: 'value5',
+        prop6: 'value6',
+        prop7: 'value7'
+      };
+
+      const tooltip = geoJson._createTooltipContent(properties);
+      const lines = tooltip.split('<br>');
+
+      expect(lines.length).toBe(5);
+    });
+
+    it('should return empty string for empty properties', () => {
+      const config = new GeoJsonConfig('zone_data', '#ff0000');
+      const geoJson = new GeoJson(config, mockEntity);
+
+      const tooltip = geoJson._createTooltipContent({});
+
+      expect(tooltip).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
This PR allows you to directly map GeoJSON from an entity into the map card and draws it on the card. It makes usage of this card very easy for more detailed usages

I've updated documentation and tests as well and finally my fork is currently running on my HA setup (included screenshot)

<img width="957" height="929" alt="image" src="https://github.com/user-attachments/assets/e5ca2eee-e6b4-43fc-9068-db87edef5b65" />


Notable feature about the GeoJSON object are:
* Select the attribute of the entity
* Colour selection of the drawing
* Weight of the lines
* Opacity of the lines
* Opacity of the area
* Hide the default marker
* Drawn areas are clickable and trigger the tapAction that is configured

Feature I might want to add for my use-case in the future:
* allow for complete HA templating by using the template rendering API in HA
or
* select colour based on an entity attribute (either provide a map value to colour, or expect the attribute to contain the colour code)

Note: This was mostly vibe coded (coded with AI assisted tooling)

Feel free to make adjustments, etc