### PR TITLE
fix: cluster_markers defaults to false and correctly handles boolean false

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ y: 3.652
 | `theme_mode`          | auto                                  | `auto`, `light` or`dark`                                                                      |
 | `focus_follow`        | none                                  | `none`, `refocus`, `contains`, reset the map focused entity's, on each update. Some people call this the `Autofit` feature.                                                              |
 | `map_options`          | {}                                                                                                                           | The `options` for the default [Leaflet Map](https://leafletjs.com/reference.html#map) |
-| `cluster_markers`      | true                                                                                                                         | Enable marker clustering to group nearby entities together. Click the group icon button to toggle clustering on/off. |
+| `cluster_markers`      | false                                                                                                                        | Enable marker clustering to group nearby entities together. Click the group icon button to toggle clustering on/off. |
 | `debug` | false                                                                                                                        | Enable debug messages in console.
 | `plugins`            | []                                                                                                                           | An array of plugin definitions, see: [Plugin Options](#plugin-options), [Available plugins](#available-plugins) and [Developing plugins](#developing-plugins)     |
 

--- a/src/configs/MapConfig.js
+++ b/src/configs/MapConfig.js
@@ -134,7 +134,7 @@ export default class MapConfig {
   }
 
   _setConfigWithDefault(input, d = null) {
-    if (!input) {
+    if (input === undefined || input === null) {
       if (d == null) {
         throw new Error("Missing key ");
       }

--- a/src/configs/MapConfig.js
+++ b/src/configs/MapConfig.js
@@ -63,8 +63,8 @@ export default class MapConfig {
     // Get theme mode.
     this.themeMode = ['dark', 'light', 'auto'].includes(inputConfig.theme_mode) ? inputConfig.theme_mode : 'auto';
 
-    // Enable marker clustering (default: true)
-    this.clusterMarkers = this._setConfigWithDefault(inputConfig.cluster_markers, true);
+    // Enable marker clustering (default: false)
+    this.clusterMarkers = this._setConfigWithDefault(inputConfig.cluster_markers, false);
 
     // Enable debug messaging. 
     // Card is quite chatty with this enabled.


### PR DESCRIPTION
## Summary

- `_setConfigWithDefault` used `!input` to check for missing values, which treated `false` as missing and fell back to the default (`true`) — so `cluster_markers: false` had no effect
- Changed the check to `input === undefined || input === null` so boolean `false` is passed through correctly
- Changed the default for `cluster_markers` from `true` to `false`

> ⚠️ **Breaking change**: existing users who rely on clustering being enabled by default will need to explicitly set `cluster_markers: true`

Fixes #193

## Test plan

- [ ] Omit `cluster_markers` — markers should not cluster (new default)
- [ ] Set `cluster_markers: false` — markers should not cluster
- [ ] Set `cluster_markers: true` — markers should cluster