### PR TITLE
Add support for non-geographic maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Home Assistant Map Card
 
-Take a look at the blog post [introducing the custom:map-card for Home Assistant](https://nathan.gs/2024/01/06/ha-map-card-a-new-and-alternative-leaflet-based-map/). 
+Take a look at the blog post [introducing the custom:map-card for Home Assistant](https://nathan.gs/2024/01/06/ha-map-card-a-new-and-alternative-leaflet-based-map/).
 
 ![An example of the custom:map-card](ha-map-card-pm25.png)
 
@@ -30,9 +30,9 @@ y: 3.652
 #### More advanced
 
 > ##### TIP
-> 
+>
 > Take a look at:
-> https://nathan.gs/2024/01/06/ha-map-card-a-new-and-alternative-leaflet-based-map/#a-more-advanced-example-measuring-pm25-air-quality-for-my-home 
+> https://nathan.gs/2024/01/06/ha-map-card-a-new-and-alternative-leaflet-based-map/#a-more-advanced-example-measuring-pm25-air-quality-for-my-home
 
 ### Options
 
@@ -59,6 +59,25 @@ y: 3.652
 | `cluster_markers`      | false                                                                                                                        | Enable marker clustering to group nearby entities together. Click the group icon button to toggle clustering on/off. |
 | `debug` | false                                                                                                                        | Enable debug messages in console.
 | `plugins`            | []                                                                                                                           | An array of plugin definitions, see: [Plugin Options](#plugin-options), [Available plugins](#available-plugins) and [Developing plugins](#developing-plugins)     |
+
+For non-geographic maps, set `map_options.crs` to `simple`. The card will translate that into Leaflet's `L.CRS.Simple`, so you can use image/floor-plan style coordinates and pair them with entity `fixed_x` / `fixed_y` values.
+
+```yaml
+type: custom:map-card
+x: 0
+y: 0
+zoom: 0
+map_options:
+  crs: simple
+  minZoom: -5
+tile_layer_url: /local/floorplan/{z}/{x}/{y}.png
+tile_layer_options:
+  noWrap: true
+entities:
+  - entity: sensor.room_temperature
+    fixed_x: 320
+    fixed_y: 180
+```
 
 
 If `x` & `y` or `focus_entity` is not set it will take the lat/long from the __first entity__.
@@ -115,10 +134,10 @@ If `history_date_selection:true`, any entities that do not define their own `his
 
 This can be added via the "Add Card" dialog by selecting Manual and entering the text `type: energy-date-selection`.
 
-Alternatively `history_start` and `history_end` can be set to 
+Alternatively `history_start` and `history_end` can be set to
 * A specific date such as  `2022-03-01T12:00:00Z`
 * A time code such as `10 days ago` `4 hours ago` `1 week ago` etc.
-* An entity that will provide either a `date` or `number` (which will be used as the amount of hours ago to show). e.g. `input_number.example_number_value` 
+* An entity that will provide either a `date` or `number` (which will be used as the amount of hours ago to show). e.g. `input_number.example_number_value`
 
 If you want to specify your own unit, configure the `history_start`/`history_end` as the below.
 ```
@@ -291,8 +310,8 @@ plugins:
 #### Available Plugins
 | name      | description                                                                                         |
 |-----------|-----------------------------------------------------------------------------------------------------|
-| [`bom-radar`](https://github.com/bezmi/ha-map-card-plugin-bom-radar) | Displays the Australian BoM rainfall radar for the past 90 minutes and the radar forecast for the next 90 minutes as an overlay on the map. | 
-| [`buienradar`](https://github.com/Kevinjil/ha-map-card-buienradar) | Displays `buienradar.nl` as an overlay on the map | 
+| [`bom-radar`](https://github.com/bezmi/ha-map-card-plugin-bom-radar) | Displays the Australian BoM rainfall radar for the past 90 minutes and the radar forecast for the next 90 minutes as an overlay on the map. |
+| [`buienradar`](https://github.com/Kevinjil/ha-map-card-buienradar) | Displays `buienradar.nl` as an overlay on the map |
 
 You can find more plugins using the [ha-map-card-plugin](https://github.com/topics/ha-map-card-plugin) topic.
 
@@ -325,7 +344,7 @@ Tag your Github repo with [ha-map-card-plugin](https://github.com/topics/ha-map-
 
 ## Mentions & Discussions
 
-* [home-assistant community: map-card: a slightly improved map-card](https://community.home-assistant.io/t/map-card-a-slightly-improved-map-card/693088), this topic should be used for general discussions. 
+* [home-assistant community: map-card: a slightly improved map-card](https://community.home-assistant.io/t/map-card-a-slightly-improved-map-card/693088), this topic should be used for general discussions.
 * [nathan.gs: Map Card, a new leaflet based map with WMS and other advanced features](https://nathan.gs/2024/01/06/ha-map-card-a-new-and-alternative-leaflet-based-map/)
 * [nathan.gs: Map Card, displaying Weather and Other Tile Layers](https://nathan.gs/2024/02/25/ha-map-card-displaying-weather-and-other-tilelayers/)
 * [userbag.co.uk: Home Assistant Exploring location history](https://userbag.co.uk/development/home-assistant-exploring-location-history/)

--- a/README.md
+++ b/README.md
@@ -70,9 +70,7 @@ zoom: 0
 map_options:
   crs: simple
   minZoom: -5
-tile_layer_url: /local/floorplan/{z}/{x}/{y}.png
-tile_layer_options:
-  noWrap: true
+tile_layer_url: ""
 entities:
   - entity: sensor.room_temperature
     fixed_x: 320

--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -193,10 +193,12 @@ export default class MapCard extends LitElement {
     // Add dark class if darkmode
     this._isDarkMode() ? mapEl.classList.add('dark') : mapEl.classList.add('light');
 
-    let tileUrl = this.urlResolver.resolveUrl(this._config.tileLayer.url);
-    let layer = new TileLayer(tileUrl, this._config.tileLayer.options);
-    map.addLayer(layer);
-    this.urlResolver.registerLayer(layer, this._config.tileLayer.url);
+    if (this._config.tileLayer) {
+      let tileUrl = this.urlResolver.resolveUrl(this._config.tileLayer.url);
+      let layer = new TileLayer(tileUrl, this._config.tileLayer.options);
+      map.addLayer(layer);
+      this.urlResolver.registerLayer(layer, this._config.tileLayer.url);
+    }
     return map;
   }
 

--- a/src/configs/MapConfig.js
+++ b/src/configs/MapConfig.js
@@ -122,12 +122,15 @@ export default class MapConfig {
       return new PluginConfig(plugin.hacs, plugin.url, plugin.name, plugin.options);
     });
 
-    this.tileLayer = new TileLayerConfig(
-      this._setConfigWithDefault(inputConfig.tile_layer_url, "https://tile.openstreetmap.org/{z}/{x}/{y}.png"),
-      this._setConfigWithDefault(inputConfig.tile_layer_options, {}),
-      null, // Default layer doesn't pass history by default.
-      this._setConfigWithDefault(inputConfig.tile_layer_attribution, '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>')
-    );
+    const tileLayerUrl = this._setConfigWithDefault(inputConfig.tile_layer_url, "https://tile.openstreetmap.org/{z}/{x}/{y}.png");
+    this.tileLayer = tileLayerUrl
+      ? new TileLayerConfig(
+          tileLayerUrl,
+          this._setConfigWithDefault(inputConfig.tile_layer_options, {}),
+          null, // Default layer doesn't pass history by default.
+          this._setConfigWithDefault(inputConfig.tile_layer_attribution, '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>')
+        )
+      : null;
     if(!(Number.isFinite(this.x) && Number.isFinite(this.y)) && this.focusEntity == null && this.entities.length == 0) {
       throw new Error("We need a map latitude & longitude; set at least [x, y], a focus_entity or have at least 1 entities defined.");
     }

--- a/src/configs/MapConfig.js
+++ b/src/configs/MapConfig.js
@@ -1,3 +1,4 @@
+import L from 'leaflet';
 import EntityConfig from "./EntityConfig.js";
 import PluginConfig from "./PluginConfig.js";
 import TileLayerConfig from "./TileLayerConfig.js";
@@ -58,7 +59,7 @@ export default class MapConfig {
     this.y = inputConfig.y;
     this.zoom = this._setConfigWithDefault(inputConfig.zoom, 12);
     this.cardSize = this._setConfigWithDefault(inputConfig.card_size, 5);
-    this.mapOptions = this._setConfigWithDefault(inputConfig.map_options, {});
+    this.mapOptions = this._normalizeMapOptions(this._setConfigWithDefault(inputConfig.map_options, {}));
 
     // Get theme mode.
     this.themeMode = ['dark', 'light', 'auto'].includes(inputConfig.theme_mode) ? inputConfig.theme_mode : 'auto';
@@ -66,7 +67,7 @@ export default class MapConfig {
     // Enable marker clustering (default: false)
     this.clusterMarkers = this._setConfigWithDefault(inputConfig.cluster_markers, false);
 
-    // Enable debug messaging. 
+    // Enable debug messaging.
     // Card is quite chatty with this enabled.
     if (inputConfig.debug){
       Logger.enableDebug();
@@ -74,7 +75,7 @@ export default class MapConfig {
 
     // Default historyStart/historyEnd can be set at the top level.
     // Entities can override these dates on an individual basis.
-    // 
+    //
     // If historyDateSelection is true, this replaces top level date functionality (and any entities that don't provide their own dates will also use this)
     this.historyDateSelection = inputConfig.history_date_selection ? true : false;
     if (this.historyDateSelection) {
@@ -144,6 +145,17 @@ export default class MapConfig {
     }
   }
 
+  _normalizeMapOptions(mapOptions) {
+    if (mapOptions?.crs === 'simple') {
+      return {
+        ...mapOptions,
+        crs: L.CRS.Simple,
+      };
+    }
+
+    return mapOptions;
+  }
+
   /** @returns {boolean} if there is a title */
   get hasTitle() {
     return this.title != null;
@@ -157,7 +169,7 @@ export default class MapConfig {
       return (this.cardSize * 50) + 20;
     }
   }
-  
+
   /** @returns {[EntityConfig]} */
   get entitiesWithShowPath() {
     return this.entities.filter((ent) => ent.showPath);

--- a/src/configs/MapConfig.test.js
+++ b/src/configs/MapConfig.test.js
@@ -14,6 +14,16 @@ describe("MapConfig", () => {
       expect(mapConfig.mapOptions.dragging).toBe(true);
     });
 
+    it("allows disabling the default tile layer", () => {
+      const mapConfig = new MapConfig({
+        x: 0.1,
+        y: 0.1,
+        tile_layer_url: "",
+      });
+
+      expect(mapConfig.tileLayer).toBeNull();
+    });
+
     it("normalizes simple CRS", () => {
       const mapConfig = new MapConfig({
         x: 0.1,

--- a/src/configs/MapConfig.test.js
+++ b/src/configs/MapConfig.test.js
@@ -1,4 +1,5 @@
 import MapConfig from "./MapConfig.js";
+import L from "leaflet";
 import { describe, expect, it } from "@jest/globals";
 
 describe("MapConfig", () => {
@@ -13,9 +14,20 @@ describe("MapConfig", () => {
       expect(mapConfig.mapOptions.dragging).toBe(true);
     });
 
-    it("complains when neither a [X, Y], an entity or a focus entity is given", () => {      
+    it("normalizes simple CRS", () => {
+      const mapConfig = new MapConfig({
+        x: 0.1,
+        y: 0.1,
+        map_options: { crs: "simple", minZoom: -4 },
+      });
+
+      expect(mapConfig.mapOptions.crs).toBe(L.CRS.Simple);
+      expect(mapConfig.mapOptions.minZoom).toBe(-4);
+    });
+
+    it("complains when neither a [X, Y], an entity or a focus entity is given", () => {
       expect(() =>  new MapConfig({})).toThrowError("We need a map latitude & longitude; set at least [x, y], a focus_entity or have at least 1 entities defined.");
     });
-    
+
   });
 });


### PR DESCRIPTION
This PR allows to set the `crs` to Leaflet's `L.CRS.Simple`, which is helpful for non-geographic maps, see the [documentation](https://leafletjs.com/examples/crs-simple/crs-simple.html). It also adds an option to remove the map tiles by setting `tile_layer_url` to the empty string, which is needed for non-geographic maps. To add the image overlay I wrote an ImageOverlayPlugin (basically the one I posted in https://github.com/nathan-gs/ha-map-card/issues/144#issuecomment-2849321760 with some smaller adjustments). If this is something wanted, I can make the plugin (and a PolylinePlugin I wrote) more accessible either by adding it here in the plugins folder or by putting it into a separate public repository or whatever you prefer @nathan-gs.
Together with the ImageOverlayPlugin this closes #144. I use it as a more powerful alternative to Home Assistant's `picture-elements` card with more flexibility and options thanks to Leaflet.

Currently, this only adds support for the `L.CRS.Simple`, but it could easily be extended to other crs (see https://leafletjs.com/reference.html#crs) by following a similar approach.

Sorry for the additional white space changes. My editor automatically removes trailing white spaces.

Note that I used the help of AI tools to create the PR, but I reviewed and tested the code.