### PR TITLE
Support SVGs using `currentColor` for marker icons

### DIFF
--- a/src/components/MapCardEntityMarker.js
+++ b/src/components/MapCardEntityMarker.js
@@ -62,7 +62,7 @@ export default class MapCardEntityMarker extends LitElement {
       `;
     }
     if(this.icon) {
-      return html`<ha-icon icon="${this.icon}" style="--icon-primary-color: ${this.color}; --mdc-icon-size: ${this.size - 10}px;">icon</ha-icon>`
+      return html`<ha-icon icon="${this.icon}" style="color: ${this.color}; --icon-primary-color: ${this.color}; --mdc-icon-size: ${this.size - 10}px;">icon</ha-icon>`
     }
     if (!this.prefix && !this.suffix) {
       return this.title;


### PR DESCRIPTION
I use custom icons (using https://github.com/thomasloven/hass-custom_icons) with SVG files using the CSS `currentColor` (as explained in https://github.com/thomasloven/hass-custom_icons#your-own-icons). However, currently the ha-map-card does not correctly apply the color for the entities with a custom icon. This PR fixes that by also passing `color` to the style of the `ha-icon`, which is inherited by `currentColor`.