### PR TITLE
Add `display: pill`: zone icon + initials marker for entities in a zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Either the name of the `entity` or:
 | name                   | Default                               | note                                                                                          |
 |------------------------|---------------------------------------|-----------------------------------------------------------------------------------------------|
 | `entity`               |                                       | The entity id                                                                                 |
-| `display`              | `marker`                              | `icon`, `state`, `attribute` or `marker`. <br/>`marker` will display the picture if available. <br/>`icon` will display the icon if available, otherwise a label composed of first letters of the entity's name |
+| `display`              | `marker`                              | `icon`, `state`, `attribute`, `marker` or `pill`. <br/>`marker` will display the picture if available. <br/>`icon` will display the icon if available, otherwise a label composed of first letters of the entity's name. <br/>`pill` shows the entity's **current zone icon + its initials** together when it is inside a Home Assistant zone, and the normal initials marker otherwise. See [Place pill](#place-pill-display-pill). |
 | `picture`              |                                       | Set a custom picture to use on the marker.                                                    |
 | `icon`                 |                                       | Set a custom icon to use if `display` is set to `icon`. e.g. `mdi:cake`                           |
 | `label`                |                                       | Set a custom text label to display on the marker (overrides auto-generated initials). Works with picture overlays.                |
@@ -106,8 +106,95 @@ Either the name of the `entity` or:
 | `z_index_offset`       | 1                                     | z-index value that determines what is displayed on top when markers overlap. (Setting a gap of at least 20 between the values assigned to each entity is recommended.) |
 | `use_base_entity_only` | false                                 | When set to `true`, the tracking will use only the base entity without including any associated device trackers. This is useful for scenarios where you want to track the base entity directly and ignore any associated trackers. |
 | `position_update_threshold` | 10                               | Distance threshold in meters. Marker position only updates if the entity has moved more than this distance. Prevents unnecessary map updates from GPS drift. Useful for clustered markers. |
+| `pill_callout_min_zoom` | 15                              | Only for `display: pill`. Map zoom at/above which the pill is drawn as an offset callout (up-left of the point, with a thin leader line to a dot on the exact location). Below this zoom the pill simply centres on the point with no leader, so it isn't obtrusive when the whole region is in view. |
 | `circle`               |                                       | Display a circle around the marker. <br/>More details [Circle options](#circle-options) |
 | `geojson`              |                                       | Display GeoJSON data from an entity attribute. <br/>More details [GeoJSON options](#geojson-options) |
+
+### Place pill (`display: pill`)
+
+A `pill` marker answers "who is where" in a single glance. When a tracked entity
+is inside a Home Assistant zone, its marker is drawn as a small stadium ("pill")
+holding two circles: the **zone's icon** on the left and the entity's **initials**
+on the right — for example a church icon next to `ML`, or a home icon next to
+`MG`. When the entity is not in any zone it falls back to the normal initials
+marker. It is opt-in per entity and changes nothing for entities that don't set
+`display: pill`.
+
+#### Why
+
+With the stock marker you can see *that* someone is on the map, but to learn
+*which named place* they're at you have to recognise the spot or click through.
+And when a person sits on top of their home/zone, you either get two overlapping
+markers or a cluster bubble showing a count. The pill folds identity and place
+into one marker — "Mom is at the church" is readable without interaction — using
+data Home Assistant already has (zones + the entity's state).
+
+#### How it resolves the person and the place
+
+There is no extra configuration linking a person to a place; it is derived live:
+
+1. **The entity is the person.** You list a `person.*` or `device_tracker.*` on
+   the map as usual. The card already places it at its GPS position and derives
+   its **initials** from the entity's `friendly_name` (first letter of each word,
+   e.g. `Mom Location` → `ML`). `label:` still overrides the initials if set.
+2. **Zones are the named places.** Each HA `zone.*` has a `friendly_name`, an
+   `icon`, a latitude/longitude and a radius. These already exist whenever you
+   create a zone (Settings → Areas & Zones).
+3. **Home Assistant links them via state.** When a `device_tracker`/`person` is
+   inside a zone, HA sets that entity's **state to the zone's name** (the Home
+   zone reports `home`). This is the join between person and place, maintained by
+   HA core — the card doesn't compute geometry.
+4. **The card reads it back.** For a `pill` entity it takes the entity's raw
+   state, finds the `zone.*` whose `friendly_name` matches it (case-insensitive;
+   `home` → the Home zone), and uses that zone's `icon` for the left circle. If
+   the state is `not_home`/`away`/unknown — or matches no zone — there is no
+   place, so the normal initials marker is shown instead.
+5. **Tooltip.** Hovering shows `<person> is at <place>`, e.g. *Mom is at
+   Extended Family*. The person name is the entity's `friendly_name` with a
+   trailing `Location`/`Tracker`/`Device`/`Phone`/`GPS` stripped, so
+   `Mom Location` reads as `Mom`. (This uses a Leaflet tooltip, which opens
+   immediately, rather than the browser's delayed native `title`.)
+
+The marker is rebuilt automatically when the entity enters or leaves a zone, so
+the pill appears, swaps icon, or collapses to initials as the person moves.
+
+#### Zoom-aware callout
+
+At/above `pill_callout_min_zoom` (default `15`) the pill is offset up-and-left of
+the exact position and connected by a thin **leader line** to a small dot on the
+real location, so the pill doesn't cover what's underneath. Below that zoom — when
+the whole town or region is in view and a leader line would just be clutter — the
+pill simply centres on the point with no leader. Set `pill_callout_min_zoom` lower
+to engage the callout sooner, or very high to effectively disable it.
+
+#### Appearance
+
+The pill reuses the entity's existing `color` (the same per-entity colour the
+normal marker uses, or whatever you set with `color:`) for the outline, icon,
+initials and leader, and `size` for each circle. Dark mode is honoured.
+
+#### Requirements
+
+- The places must be real HA **zones** with an `icon` and a `friendly_name`
+  (icons like `mdi:home`, `mdi:church`, `mdi:account-group`).
+- The entity must report its zone in its **state** — GPS `device_tracker`s and
+  `person`s do this automatically; the Home zone reports `home`.
+
+#### Example
+
+```yaml
+type: custom:map-card
+entities:
+  - entity: device_tracker.mom_location
+    display: pill
+  - entity: person.matt
+    display: pill
+    pill_callout_min_zoom: 14   # show the offset callout a bit sooner
+```
+
+With `device_tracker.mom_location` in the *Extended Family* zone this renders a
+pill of `mdi:account-group` + `ML`, tooltip "Mom is at Extended Family"; when she
+leaves it becomes a plain `ML` marker.
 
 ### History options
 

--- a/src/components/MapCardEntityMarker.js
+++ b/src/components/MapCardEntityMarker.js
@@ -10,6 +10,8 @@ export default class MapCardEntityMarker extends LitElement {
       'tooltip': {type: String, attribute: 'tooltip'},
       'picture': {type: String, attribute: 'picture'},
       'icon': {type: String, attribute: 'icon'},
+      'placeIcon': {type: String, attribute: 'place-icon'},
+      'callout': {type: String, attribute: 'callout'},
       'color': {type: String, attribute: 'color'},
       'size': {type: Number},
       'tapAction': {type: Object, attribute: 'tap-action'},
@@ -18,12 +20,56 @@ export default class MapCardEntityMarker extends LitElement {
   }
 
   render() {
+    // When the entity is inside a named place, render a horizontal "pill":
+    // a stadium outline holding two circles - the zone icon (left) and the
+    // entity's initials (right). Otherwise fall back to the normal marker.
+    if (this.placeIcon) {
+      // Pill: zone icon (left) + initials (right). Geometry must match
+      // Entity.createMapMarker. When `callout` is on (zoomed in) the pill sits
+      // up-left of the point with a thin leader line down-right to a dot on the
+      // exact location; otherwise it just centers on the point (no leader).
+      const s = this.size;
+      const pillW = 2 * s + 14;
+      const pillH = s + 8;
+      const pill = html`
+        <div class="place-pill" style="border-color: ${this.color}; width: ${pillW}px; height: ${pillH}px;">
+          <div class="pill-badge" style="border-color: ${this.color}; width: ${s}px; height: ${s}px;">
+            <ha-icon icon="${this.placeIcon}" style="--icon-primary-color: ${this.color}; --mdc-icon-size: ${s - 14}px;"></ha-icon>
+          </div>
+          <div class="pill-badge pill-initials" style="border-color: ${this.color}; color: ${this.color}; width: ${s}px; height: ${s}px; font-size: ${Math.round(s * 0.5)}px;">
+            ${this.title}
+          </div>
+        </div>`;
+      if (this.callout !== "true") {
+        return html`
+          <div class="place-pill-wrap ${this.extraCssClasses ? this.extraCssClasses : ""}"
+               style="width: ${pillW}px; height: ${pillH}px;"
+               @click=${this._badgeTap}>
+            ${pill}
+          </div>`;
+      }
+      const off = Math.round(s * 0.7);
+      const boxW = pillW + off;
+      const boxH = pillH + off;
+      const dotX = boxW - 2, dotY = boxH - 2;
+      return html`
+        <div class="place-pill-wrap ${this.extraCssClasses ? this.extraCssClasses : ""}"
+             style="width: ${boxW}px; height: ${boxH}px;"
+             @click=${this._badgeTap}>
+          <svg class="pill-leader" width="${boxW}" height="${boxH}">
+            <line x1="${pillW - 2}" y1="${pillH - 2}" x2="${dotX}" y2="${dotY}"
+                  stroke="${this.color}" stroke-width="1.5"></line>
+            <circle cx="${dotX}" cy="${dotY}" r="2.5" fill="${this.color}"></circle>
+          </svg>
+          ${pill}
+        </div>
+      `;
+    }
     return html`
         <div
           class="marker ${this.picture ? "picture" : ""}  ${this.extraCssClasses ? this.extraCssClasses : ""}"
           style="border-color: ${this.color}; height: ${this.size}px; width: ${this.size}px;"
           @click=${this._badgeTap}
-          title="${this.tooltip}"
           >
           ${this._inner()}
         </div>
@@ -122,6 +168,53 @@ export default class MapCardEntityMarker extends LitElement {
       }
       .suffix {
         margin-left: var(--ha-marker-suffix-margin, 2px);
+      }
+      .place-pill-wrap {
+        position: relative;
+      }
+      .pill-leader {
+        position: absolute;
+        left: 0;
+        top: 0;
+        overflow: visible;
+        pointer-events: none;
+      }
+      .place-pill {
+        position: absolute;
+        left: 0;
+        top: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 2px;
+        box-sizing: border-box;
+        padding: 3px 5px;
+        border-radius: 999px;
+        border: 1px solid var(--ha-marker-color, var(--primary-color));
+        background-color: var(--card-background-color);
+        font-size: var(--ha-marker-font-size, 1.5em);
+        white-space: nowrap;
+      }
+      .place-pill .pill-badge {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        box-sizing: border-box;
+        border-radius: 50%;
+        border: 1px solid var(--ha-marker-color, var(--primary-color));
+        background-color: var(--card-background-color);
+        color: var(--primary-text-color);
+        flex: 0 0 auto;
+      }
+      .place-pill .pill-initials {
+        font-weight: 700;
+        text-align: center;
+        line-height: 1;
+      }
+      .place-pill.dark,
+      .place-pill.dark .pill-badge {
+        color: #ffffff;
+        background: #1c1c1c;
       }
     `;
   }

--- a/src/configs/EntityConfig.js
+++ b/src/configs/EntityConfig.js
@@ -67,6 +67,11 @@ export default class EntityConfig {
   useBaseEntityOnly;
   /** @type {number} */
   positionUpdateThreshold;
+  /**
+   * @type {number} Min map zoom at which a `display: pill` marker shows the
+   * offset callout + leader line; below it the pill centers on the point.
+   */
+  pillCalloutMinZoom;
 
   /** @type {CircleConfig} */
   circleConfig;
@@ -132,6 +137,7 @@ export default class EntityConfig {
 
     this.useBaseEntityOnly = config.use_base_entity_only ?? false;
     this.positionUpdateThreshold = config.position_update_threshold ?? 10;
+    this.pillCalloutMinZoom = config.pill_callout_min_zoom ?? 15;
 
     this.circleConfig = new CircleConfig(config.circle, this.color);
     this.geoJsonConfig = new GeoJsonConfig(config.geojson, this.color);

--- a/src/configs/EntityConfig.test.js
+++ b/src/configs/EntityConfig.test.js
@@ -8,6 +8,18 @@ describe("EntityConfig", () => {
     historyEnd: null
   };
 
+  describe("pillCalloutMinZoom", () => {
+    it("defaults to 15", () => {
+      const entityConfig = new EntityConfig({ entity: "device_tracker.mom" }, defaults);
+      expect(entityConfig.pillCalloutMinZoom).toBe(15);
+    });
+
+    it("can be overridden via pill_callout_min_zoom", () => {
+      const entityConfig = new EntityConfig({ entity: "device_tracker.mom", pill_callout_min_zoom: 12 }, defaults);
+      expect(entityConfig.pillCalloutMinZoom).toBe(12);
+    });
+  });
+
   describe("_generateRandomColor", () => {
     it("should generate a random color", () => {
       const entityConfig = new EntityConfig("sensor.random_entity", defaults);

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -171,10 +171,45 @@ export default class Entity {
       }
       // Initialize last set position to prevent immediate update
       this._lastSetLatLng = this.latLng;
+      // Track the current place so update() can recreate the pill on zone change
+      this._currentPlaceIcon = this.placeIcon;
+      this._clusterGroup = clusterGroup;
+      // For `display: pill`, the offset callout + leader only show at/above
+      // pillCalloutMinZoom; recreate the marker when zoom crosses that boundary
+      // so it isn't obtrusive when zoomed out region-wide.
+      if (this.display == "pill") {
+        this._calloutActive = this.map.getZoom() >= this.config.pillCalloutMinZoom;
+        this._onZoomEnd = () => {
+          if (!this.marker) return;
+          const active = this.map.getZoom() >= this.config.pillCalloutMinZoom;
+          if (active !== this._calloutActive) {
+            this._calloutActive = active;
+            this._recreateMarker();
+          }
+        };
+        this.map.on("zoomend", this._onZoomEnd);
+      }
     }
     this.historyManager.setup();
     this.circle.setup();
     this.geoJson.setup();
+  }
+
+  /**
+   * Remove and rebuild the marker in place (preserving cluster membership).
+   * @private
+   */
+  _recreateMarker() {
+    const cg = this._clusterGroup;
+    this.marker.remove();
+    this.marker = this.createMapMarker();
+    if (cg) {
+      cg.addLayer(this.marker);
+    } else {
+      this.marker.addTo(this.map);
+    }
+    this._currentTitle = this.title;
+    this._currentPlaceIcon = this.placeIcon;
   }
 
   /** @param {TimelineEntry} entry */
@@ -216,11 +251,59 @@ export default class Entity {
 
   /** @returns {string} */
   get tooltip() {
+    // placeName only resolves in pill mode and when inside a zone.
+    const placeName = this.placeName;
+    if (placeName) {
+      // "<person> is at <place>" - strip a trailing tracker-ish suffix so
+      // "Mom Location" reads as "Mom is at Extended Family".
+      const who = (this.friendlyName ?? "").replace(/\s+(location|tracker|device|phone|gps)$/i, "");
+      return `${who} is at ${placeName}`;
+    }
     return this.friendlyName ?? "";
   }
 
   get icon() {
     return this.config.icon ?? this.attributes.icon;
+  }
+
+  /**
+   * The HA zone state object the entity is currently inside (a "named place"),
+   * or null when it isn't in one. Drives the place-pill marker. Matches the
+   * entity's RAW state against each zone's friendly_name (case-insensitive);
+   * the home zone reports state "home".
+   * @returns {object|null}
+   */
+  get zoneState() {
+    const raw = this.hass.states[this.id]?.state;
+    if (!raw || ["not_home", "away", "unknown", "unavailable"].includes(raw.toLowerCase())) {
+      return null;
+    }
+    const target = raw.toLowerCase();
+    for (const eid in this.hass.states) {
+      if (!eid.startsWith("zone.")) continue;
+      const fn = (this.hass.states[eid].attributes?.friendly_name ?? "").toLowerCase();
+      if (fn && fn === target) {
+        return this.hass.states[eid];
+      }
+    }
+    if (target === "home" && this.hass.states["zone.home"]) {
+      return this.hass.states["zone.home"];
+    }
+    return null;
+  }
+
+  /** @returns {string|null} mdi icon of the current named place (pill mode only). */
+  get placeIcon() {
+    if (this.display != "pill") return null;
+    const z = this.zoneState;
+    return z ? (z.attributes?.icon ?? "mdi:map-marker") : null;
+  }
+
+  /** @returns {string|null} friendly_name of the current named place (pill mode only). */
+  get placeName() {
+    if (this.display != "pill") return null;
+    const z = this.zoneState;
+    return z ? (z.attributes?.friendly_name ?? null) : null;
   }
 
   /**
@@ -267,22 +350,25 @@ export default class Entity {
   async update(clusterGroup = null) {
     // Only update marker if it exists (not hidden by GeoJSON config)
     if (this.marker) {
-      if(this.display == "state" || this.display == "attribute") {
-        if(this.title != this._currentTitle) {
-          Logger.debug("[Entity] updating marker for " + this.id + " from " + this._currentTitle + " to " + this.title);
-          // When recreating marker, we need to track if it was in a cluster
-          const wasInCluster = clusterGroup && clusterGroup.hasLayer(this.marker);
-          this.marker.remove();
-          this.marker = this.createMapMarker();
-          if (wasInCluster) {
-            clusterGroup.addLayer(this.marker);
-          } else if (clusterGroup) {
-            clusterGroup.addLayer(this.marker);
-          } else {
-            this.marker.addTo(this.map);
-          }
-          this._currentTitle = this.title;
+      // Recreate the marker when the display title changes (state/attribute
+      // modes) OR when the entity enters/leaves a named place (place-pill).
+      const titleChanged = (this.display == "state" || this.display == "attribute") && this.title != this._currentTitle;
+      const placeIconChanged = this.placeIcon != this._currentPlaceIcon;
+      if (titleChanged || placeIconChanged) {
+        Logger.debug("[Entity] recreating marker for " + this.id + " (title/place change)");
+        // When recreating marker, we need to track if it was in a cluster
+        const wasInCluster = clusterGroup && clusterGroup.hasLayer(this.marker);
+        this.marker.remove();
+        this.marker = this.createMapMarker();
+        if (wasInCluster) {
+          clusterGroup.addLayer(this.marker);
+        } else if (clusterGroup) {
+          clusterGroup.addLayer(this.marker);
+        } else {
+          this.marker.addTo(this.map);
         }
+        this._currentTitle = this.title;
+        this._currentPlaceIcon = this.placeIcon;
       }
 
       // Update position only if it has changed significantly (configurable threshold in meters)
@@ -316,8 +402,27 @@ export default class Entity {
     }
 
     const extraCssClasses = this.darkMode ? "dark" : "";
+    // Pill mode (opt-in via display: pill): zone icon + initials when the entity
+    // is in a named place; falls back to the normal initials marker otherwise.
+    // placeIcon already returns null unless display === "pill".
+    const placeIcon = this.placeIcon;
+    if (this.display == "pill") {
+      icon = null;
+    }
+    // Pill-callout geometry (must match MapCardEntityMarker's pill render): the
+    // pill sits up-left of the point with a short leader line down-right to a
+    // dot on the exact location, so it doesn't cover what's underneath. The
+    // callout only engages at/above pillCalloutMinZoom; zoomed out, the pill
+    // centers on the point with no leader (so it isn't obtrusive region-wide).
+    const s = this.config.size;
+    const pillW = 2 * s + 14;
+    const pillH = s + 8;
+    const off = Math.round(s * 0.7);
+    const boxW = pillW + off;
+    const boxH = pillH + off;
+    const callout = placeIcon != null && this.map.getZoom() >= this.config.pillCalloutMinZoom;
 
-    return new Marker(this.latLng, {
+    const marker = new Marker(this.latLng, {
       icon: new DivIcon({
         html: `
           <map-card-entity-marker
@@ -328,6 +433,8 @@ export default class Entity {
             tooltip="${this.tooltip}"
             icon="${icon ?? ""}"
             picture="${picture ?? ""}"
+            place-icon="${placeIcon ?? ""}"
+            callout="${callout}"
             color="${this.config.color}"
             style="${this.config.css}"
             size="${this.config.size}"
@@ -335,11 +442,21 @@ export default class Entity {
             tap-action='${JSON.stringify(this.config.tapAction)}'
           ></map-card-entity-marker>
         `,
-        iconSize: [this.config.size, this.config.size],
+        iconSize: placeIcon ? (callout ? [boxW, boxH] : [pillW, pillH]) : [s, s],
+        iconAnchor: placeIcon ? (callout ? [boxW - 2, boxH - 2] : [pillW / 2, pillH / 2]) : [s / 2, s / 2],
         className: ''
       }),
-      title: this.id,
       zIndexOffset: this.config.zIndexOffset
     });
+    // Instant hover label: a Leaflet tooltip opens on mouseover with no delay,
+    // unlike the native `title` attribute (which the browser holds ~1s). The
+    // distance feature (setup) rebinds a permanent tooltip when configured.
+    if (!this.config.distanceEntity) {
+      marker.bindTooltip(this.tooltip, {
+        direction: "top",
+        offset: [0, -this.config.size / 2 - 4]
+      });
+    }
+    return marker;
   }
 }

--- a/src/models/Entity.test.js
+++ b/src/models/Entity.test.js
@@ -230,3 +230,54 @@ describe('Entity class', () => {
   });
 
 });
+
+describe('Entity place pill (display: pill)', () => {
+  const map = { addTo: jest.fn() };
+  const noop = jest.fn();
+  const zones = {
+    'zone.home': { state: 'zoning', attributes: { friendly_name: 'Home', icon: 'mdi:home' } },
+    'zone.extended_family': { state: 'zoning', attributes: { friendly_name: 'Extended Family', icon: 'mdi:account-group' } },
+  };
+
+  const makeEntity = (display, state) => {
+    const hass = {
+      states: {
+        ...zones,
+        'device_tracker.mom_location': { state, attributes: { friendly_name: 'Mom Location', latitude: 1, longitude: 2 } },
+      },
+      formatEntityState: jest.fn(s => (s ? s.state : '')),
+      hassUrl: jest.fn(u => u),
+    };
+    const config = {
+      id: 'device_tracker.mom_location', display, attribute: '', prefix: '', suffix: '',
+      label: null, size: 48, color: 'red', zIndexOffset: 0, tapAction: {}, css: '',
+      circleConfig: {}, geoJsonConfig: {}, pillCalloutMinZoom: 15,
+    };
+    return new Entity(config, hass, map, noop, noop, noop, false);
+  };
+
+  it('placeIcon returns the zone icon when in a named zone', () => {
+    expect(makeEntity('pill', 'Extended Family').placeIcon).toBe('mdi:account-group');
+  });
+  it('placeIcon resolves the Home zone from state "home"', () => {
+    expect(makeEntity('pill', 'home').placeIcon).toBe('mdi:home');
+  });
+  it('placeIcon is null when the entity is not in a zone', () => {
+    expect(makeEntity('pill', 'not_home').placeIcon).toBeNull();
+  });
+  it('placeIcon is null when display is not pill, even inside a zone', () => {
+    expect(makeEntity('marker', 'Extended Family').placeIcon).toBeNull();
+  });
+  it('placeName returns the zone friendly name', () => {
+    expect(makeEntity('pill', 'Extended Family').placeName).toBe('Extended Family');
+  });
+  it('tooltip reads "<person> is at <place>" and strips a tracker suffix', () => {
+    expect(makeEntity('pill', 'Extended Family').tooltip).toBe('Mom is at Extended Family');
+  });
+  it('tooltip falls back to the friendly name when not in a zone', () => {
+    expect(makeEntity('pill', 'not_home').tooltip).toBe('Mom Location');
+  });
+  it('tooltip is the friendly name when display is not pill', () => {
+    expect(makeEntity('marker', 'Extended Family').tooltip).toBe('Mom Location');
+  });
+});


### PR DESCRIPTION
# Add `display: pill` — zone icon + initials marker for entities in a place

## Summary

Adds an opt-in entity display mode, `display: pill`. When a tracked entity is
inside a Home Assistant zone, its marker renders as a small stadium ("pill")
holding two circles — the **zone's icon** and the entity's **initials** — so the
map shows *who is where* at a glance (e.g. a church icon next to `ML`). When the
entity isn't in a zone it falls back to the existing initials marker. Nothing
changes for entities that don't set `display: pill`.

## Motivation

The stock marker tells you *that* someone is on the map, but not *which named
place* they're at without recognising the spot or clicking through. And when a
person sits on their home/zone you get overlapping markers or a cluster bubble
with a count. This folds identity + place into one marker using data HA already
maintains — no template sensors, no helper entities.

It's a common ask for family-location dashboards ("Mom is at the doctor / at
church / at home") and it reuses the card's existing zone/entity data rather than
adding a new data source.

## How it works

No configuration links a person to a place — it's derived live from state HA
already keeps:

- The entity (`person`/`device_tracker`) supplies the position and the initials
  (from `friendly_name`, same logic as today; `label` still overrides).
- HA sets a tracker/person's **state to the zone's name** when it's inside one
  (the Home zone reports `home`). That is the person↔place join, maintained by HA
  core.
- For a `pill` entity the card matches the raw state to the `zone.*` whose
  `friendly_name` equals it (case-insensitive; `home` → the Home zone) and uses
  that zone's `icon`. No state match → no place → normal initials marker.
- Hover shows `<person> is at <place>` via a Leaflet tooltip (opens immediately,
  unlike the native `title`).

Markers are rebuilt on zone enter/leave, so the pill appears/swaps/collapses as
the entity moves. Full write-up in the README ("Place pill" section).

## Zoom-aware callout

At/above `pill_callout_min_zoom` (default `15`) the pill is offset up-left of the
point with a thin leader line to a dot on the exact location, so it doesn't cover
what's underneath. Below that zoom — region in view, where a leader is just
clutter — the pill centres on the point with no leader. Configurable per entity.

## Why it's safe to merge

- **Opt-in.** Default `display` is unchanged; the pill only renders for entities
  explicitly set to `display: pill`. Zero visual change for existing users.
- **No new dependencies.** Reuses `<ha-icon>`, the existing Leaflet tooltip
  mechanism, and the existing `color`/`size`/`label` options.
- **Small, isolated.** Marker rendering only; falls through to the existing path
  for every other mode. One new optional config key (`pill_callout_min_zoom`).
- **Documented.** README updated (option table + a dedicated section).

## Changes

- `src/configs/EntityConfig.js` — parse `pill_callout_min_zoom` (default 15).
- `src/models/Entity.js` — `zoneState`/`placeIcon`/`placeName` getters; `pill`
  branch in `createMapMarker` (zone-icon attr, callout geometry/anchor); rebuild
  on zone enter/leave and on the zoom threshold crossing; `is at` tooltip; bind a
  Leaflet tooltip for instant hover.
- `src/components/MapCardEntityMarker.js` — `place-icon`/`callout` attributes;
  pill render (two circles, optional leader) + styles.
- `README.md` — `display: pill` + `pill_callout_min_zoom` docs.
- `src/models/Entity.test.js`, `src/configs/EntityConfig.test.js` — unit tests
  for the zone resolution, tooltip and the new config option.

## Relationship to #196 (Map marker badges)

I'm aware of the open #196 "Map marker badges" — a general, user-configured
multi-badge system. This is intentionally narrower and complementary: a single,
zero-config display mode whose distinguishing piece is that it **derives the
place from the entity's state ↔ zone automatically** (icon + "is at …" tooltip),
which the manual badge config doesn't do. They're not mutually exclusive, and if
you'd prefer this land as a preset on top of the badge framework rather than a
separate `display` value, I'm happy to rework it that way — just say which you
prefer.

## Backward compatibility

Fully compatible. No removed/renamed options; default behaviour identical. The
only state-dependent behaviour (zone match, tooltip wording) is gated behind
`display: pill`.

## Testing

`npm run lint` clean and `npm test` green (added 10 unit tests covering zone
resolution, the `… is at …` tooltip, the `display`-gating, and the new config
default/override; full suite 145 passing). Built with `npm run build` and run
against a live HA instance: a person moving
between Home, a church zone and a family zone shows the correct zone icon +
initials and the `… is at …` tooltip; leaving all zones falls back to the
initials marker; the offset callout + leader engage on zoom-in and collapse on
zoom-out at the configured threshold; entities without `display: pill` are
unchanged.

## Screenshots

<!-- add: pill at street zoom (icon + initials + leader); pill collapsed at region zoom; tooltip -->
