### PR TITLE
Preserve Leaflet map on dynamic entity configuration updates

### DIFF
--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -203,9 +203,70 @@ export default class MapCard extends LitElement {
 
 
   setConfig(config) {
+    const previousConfig = this.config;
+    const newMapConfig = new MapConfig(config);
+
+    const entitiesOnlyChanged =
+      previousConfig &&
+      this.map &&
+      this.entitiesRenderService &&
+      this._sameConfigExceptEntities(previousConfig, config);
+
     this.config = config;
-    this._config = new MapConfig(config);
+    this._config = newMapConfig;
+
+    if (entitiesOnlyChanged) {
+      const changedEntityIds = this._getChangedEntityIds(
+        previousConfig.entities ?? [],
+        config.entities ?? []
+      );
+
+      this.entitiesRenderService.reconfigure(
+        newMapConfig.entities,
+        this.hass,
+        changedEntityIds
+      );
+
+      this.setupNeeded = false;
+      return;
+    }
+
     this.setupNeeded = true;
+  }
+
+  _sameConfigExceptEntities(oldConfig, newConfig) {
+    const { entities: oldEntities, ...oldMapConfig } = oldConfig;
+    const { entities: newEntities, ...newMapConfig } = newConfig;
+
+    oldEntities;
+    newEntities;
+
+    return JSON.stringify(oldMapConfig) === JSON.stringify(newMapConfig);
+  }
+
+  _getChangedEntityIds(oldEntities, newEntities) {
+    const oldById = new Map(
+      oldEntities.map((entity) => [this._getEntityId(entity), entity])
+    );
+
+    const newById = new Map(
+      newEntities.map((entity) => [this._getEntityId(entity), entity])
+    );
+
+    const allIds = new Set([
+      ...oldById.keys(),
+      ...newById.keys()
+    ]);
+
+    return new Set(
+      [...allIds].filter((id) => {
+        return JSON.stringify(oldById.get(id)) !== JSON.stringify(newById.get(id));
+      })
+    );
+  }
+
+  _getEntityId(entity) {
+    return typeof entity === "string" ? entity : entity.entity;
   }
 
   // The height of your card. Home Assistant uses this to automatically

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -342,4 +342,28 @@ export default class Entity {
       zIndexOffset: this.config.zIndexOffset
     });
   }
+
+  cleanup(clusterGroup = null) {
+    this.historyManager.cleanup();
+
+    if (this.marker) {
+      if (clusterGroup && clusterGroup.hasLayer(this.marker)) {
+        clusterGroup.removeLayer(this.marker);
+      } else {
+        this.marker.remove();
+      }
+
+      this.marker = null;
+    }
+
+    if (this.circle?.circle) {
+      this.circle.circle.remove();
+      this.circle.circle = null;
+    }
+
+    if (this.geoJson?.geoJsonLayer) {
+      this.geoJson.geoJsonLayer.remove();
+      this.geoJson.geoJsonLayer = null;
+    }
+  }
 }

--- a/src/models/EntityHistoryManager.js
+++ b/src/models/EntityHistoryManager.js
@@ -141,4 +141,16 @@ export default class EntityHistoryManager {
       marker.addTo(this.historyLayerGroup);
     });
   }
+
+  cleanup() {
+    this.historyService.unsubscribeEntity(this.entity.id);
+
+    if (this.historyLayerGroup) {
+      this.historyLayerGroup.remove();
+      this.historyLayerGroup = null;
+    }
+
+    this.history = null;
+  }
+
 }

--- a/src/services/render/EntitiesRenderService.js
+++ b/src/services/render/EntitiesRenderService.js
@@ -1,4 +1,4 @@
-import L, {Map, LayerGroup, LatLngBounds} from "leaflet";
+import L, {LayerGroup, LatLngBounds} from "leaflet";
 import "leaflet.markercluster";
 import EntityConfig from "../../configs/EntityConfig";
 import Entity from "../../models/Entity";
@@ -59,21 +59,82 @@ export default class EntitiesRenderService {
       Logger.debug("[EntitiesRenderService] Marker cluster group created and added to map");
     }
 
-    this.entities = this.entityConfigs.map((configEntity) => {
-      // Attempt to setup entity. Skip on fail, so one bad entity does not affect others.
-      try {
-        const entity = new Entity(configEntity, this.hass, this.map, this.historyService, this.dateRangeManager, this.linkedEntityService, this.isDarkMode);
-        entity.setup(this.markerClusterGroup);
-        return entity;
-      } catch (e){
-        Logger.error("Entity: " + configEntity.id + " skipped due to missing data", e);
-        HaMapUtilities.renderWarningOnMap(this.map, "Entity: " + configEntity.id + " could not be loaded. See console for details.");
-        return null;
-      }
-    })
-    // Remove skipped entities.
-    .filter(v => v);
+    this.entities = this.entityConfigs
+      .map((configEntity) => this._createEntity(configEntity))
+      .filter((entity) => entity);
 
+  }
+
+  _createEntity(configEntity) {
+    try {
+      const entity = new Entity(
+        configEntity,
+        this.hass,
+        this.map,
+        this.historyService,
+        this.dateRangeManager,
+        this.linkedEntityService,
+        this.isDarkMode
+      );
+
+      entity.setup(this.markerClusterGroup);
+
+      return entity;
+    } catch (e) {
+      Logger.error(
+        "Entity: " + configEntity.id + " skipped due to missing data",
+        e
+      );
+
+      HaMapUtilities.renderWarningOnMap(
+        this.map,
+        "Entity: " + configEntity.id + " could not be loaded. See console for details."
+      );
+
+      return null;
+    }
+  }
+
+  reconfigure(entityConfigs, hass, changedEntityIds = new Set()) {
+    this.hass = hass;
+
+    const existingEntities = new Map(
+      this.entities.map((entity) => [entity.id, entity])
+    );
+
+    const nextEntities = [];
+
+    entityConfigs.forEach((configEntity) => {
+      const existingEntity = existingEntities.get(configEntity.id);
+
+      // Keep completely unchanged entities alive.
+      if (existingEntity && !changedEntityIds.has(configEntity.id)) {
+        existingEntity.hass = hass;
+        nextEntities.push(existingEntity);
+        existingEntities.delete(configEntity.id);
+        return;
+      }
+
+      // Same entity ID, but its visual/configuration changed.
+      if (existingEntity) {
+        existingEntity.cleanup(this.markerClusterGroup);
+        existingEntities.delete(configEntity.id);
+      }
+
+      const newEntity = this._createEntity(configEntity);
+
+      if (newEntity) {
+        nextEntities.push(newEntity);
+      }
+    });
+
+    // Anything still here disappeared from the new configuration.
+    existingEntities.forEach((entity) => {
+      entity.cleanup(this.markerClusterGroup);
+    });
+
+    this.entityConfigs = entityConfigs;
+    this.entities = nextEntities;
   }
 
   async render() {

--- a/src/util/HaMapUtilities.js
+++ b/src/util/HaMapUtilities.js
@@ -1,4 +1,5 @@
 import L from 'leaflet';
+const warningControls = new WeakMap();
 
 /**
  * Shared utility methods for HaMapCard
@@ -52,11 +53,46 @@ export default class HaMapUtilities {
 
   // Show error message
   static renderWarningOnMap(map, message) {
-    L.control.attribution({prefix:'⚠️'}).addAttribution(message).addTo(map);
+    let warningState = warningControls.get(map);
+
+    if (!warningState) {
+      const control = L.control.attribution({
+        prefix: '⚠️'
+      }).addTo(map);
+
+      warningState = {
+        control,
+        messages: new Set()
+      };
+
+      warningControls.set(map, warningState);
+    }
+
+    // Don't add the same warning more than once.
+    if (warningState.messages.has(message)) {
+      return;
+    }
+
+    warningState.control.addAttribution(message);
+    warningState.messages.add(message);
   }
+
   // Hide error message
   static removeWarningOnMap(map, message) {
-    L.control.attribution({prefix:'⚠️'}).removeAttribution(message).addTo(map);
+    const warningState = warningControls.get(map);
+
+    if (!warningState || !warningState.messages.has(message)) {
+      return;
+    }
+
+    warningState.control.removeAttribution(message);
+    warningState.messages.delete(message);
+
+    // If there are no warnings left, remove the warning control entirely.
+    if (warningState.messages.size === 0) {
+      map.removeControl(warningState.control);
+      warningControls.delete(map);
+    }
   }
 
   // Get Lat/Lng of entity. Some entities such as "person" define device_trackers allowing


### PR DESCRIPTION
I use ha-map-card with auto-entities to display frequently changing geo_location data, most notably Blitzortung lightning strikes. New strikes are added as they arrive, and existing strikes move through different size/color groups as they age before eventually disappearing. Because auto-entities updates the card configuration whenever that generated entity list changes, ha-map-card was rebuilding the entire Leaflet map for each of those updates. During active weather this could mean repeatedly recreating the base tile layer for every new strike or age transition, causing unnecessary tile requests, visible map refreshes, and loss of the efficiency Leaflet normally provides by keeping the underlying map in place while only changing its data layers. The goal of this change is to let dynamic entity sets update normally—adding, changing, and removing markers—without recreating the underlying map when the map configuration itself has not changed.

- Dynamic cards such as auto-entities call setConfig() whenever their generated entity list changes.
- map-card currently interprets every setConfig() as requiring full setup.
- Full setup removes and recreates the Leaflet map and base tile layer.
- This PR detects entity-only configuration changes and reconciles entities instead.
- Unchanged entities remain intact.
- Added entities are created.
- removed entities and their history layers are cleaned up.
- entities whose configuration changes are individually recreated.
- map/tile configuration changes still take the existing full-rebuild path.
- You tested this against a rapidly changing set of geo_location entities where entities are added, removed, and restyled based on age.
- Base tiles remain loaded and current pan/zoom state is preserved.

During testing, repeated failed entity creation exposed that each warning created a new Leaflet attribution control. Warning controls are now reused and duplicate messages suppressed.

-  Related to #70. That issue discusses using auto-entities as a workaround for dynamically displaying Blitzortung geo_location entities. This PR does not implement native geo_location_sources support, but it makes that dynamic-entity approach substantially more efficient by avoiding a complete Leaflet map/tile-layer rebuild each time the generated entity list changes.
- Also partially related to #133: repeated failures for a temporarily unavailable/missing entity no longer create additional duplicate warning controls on each reconfiguration. This does not add a general option to suppress entity warnings.

Example config:

_In this setup, new lightning entities are continuously added, existing entities move between age-based style groups, and old entities are removed, causing auto-entities to repeatedly call setConfig() on the same map-card._

```
type: custom:auto-entities
card:
  type: custom:map-card
  history_start: 2 hours ago
  zoom: 12
  tile_layer_url: https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png

filter:
  include:
    - domain: geo_location
      attributes:
        source: blitzortung
      last_updated: < 1m ago
      options:
        display: icon
        icon: mdi:circle
        size: 20
        color: "#ff0000"
        focus_on_fit: false

    - domain: geo_location
      attributes:
        source: blitzortung
      last_updated 1: "> 1m ago"
      last_updated 2: < 5m ago
      options:
        display: icon
        icon: mdi:circle
        size: 15
        color: "#fff200"
        focus_on_fit: false

    - domain: geo_location
      attributes:
        source: blitzortung
      last_updated: "> 30m ago"
      options:
        display: icon
        icon: mdi:circle
        size: 3
        color: "#757575"
        focus_on_fit: false
```

