### PR TITLE
Avoid calling InitialViewRenderService.setup() on resize events

### DIFF
--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -170,7 +170,6 @@ export default class MapCard extends LitElement {
       for (let entry of entries) {
         if (entry.target === this.map?.getContainer()) {
           this.map?.invalidateSize();
-          this.initialViewRenderService?.setup();
         }
       }
     });

--- a/src/services/render/InitialViewRenderService.js
+++ b/src/services/render/InitialViewRenderService.js
@@ -21,6 +21,32 @@ export default class InitialViewRenderService {
 
   setup() {
     Logger.debug("[InitialViewRenderService] Setting up initial view");
+    const container = this.map?.getContainer();
+
+    if (!container) return;
+
+    // If the container is already sized, apply the view immediately. Otherwise,
+    // use a one-shot ResizeObserver to wait for the browser to lay out the
+    // container, then apply the view once real dimensions are available.
+    if (container.clientWidth > 0 && container.clientHeight > 0) {
+      this._applyInitialView();
+    } else {
+      const observer = new ResizeObserver(() => {
+        observer.disconnect();
+        try {
+          if (this.map?.getContainer()?.isConnected) {
+            this.map.invalidateSize();
+            this._applyInitialView();
+          }
+        } catch (e) {
+          Logger.debug("[InitialViewRenderService] Map no longer available, skipping initial view", e);
+        }
+      });
+      observer.observe(container);
+    }
+  }
+
+  _applyInitialView() {
     const latLng = this.getConfiguredLatLong(this.config, this.hass);
     
     if (latLng) {

--- a/src/services/render/InitialViewRenderService.test.js
+++ b/src/services/render/InitialViewRenderService.test.js
@@ -1,3 +1,4 @@
+import { jest, describe, it, expect } from '@jest/globals';
 import InitialViewRenderService from "./InitialViewRenderService";
 
 describe("InitialViewRenderService", () => {
@@ -10,6 +11,51 @@ describe("InitialViewRenderService", () => {
   describe("setup", () => {
     it("should have a method", () => {
       expect(new InitialViewRenderService().setup).toBeDefined();
+    });
+
+    it("should apply the view immediately when the container is already sized", () => {
+      const MockResizeObserver = jest.fn();
+      globalThis.ResizeObserver = MockResizeObserver;
+
+      const map = {
+        getContainer: () => ({ clientWidth: 100, clientHeight: 100 }),
+        setView: jest.fn()
+      };
+      const config = { x: 51, y: 3, zoom: 12 };
+      const service = new InitialViewRenderService(map, config, {}, {});
+
+      service.setup();
+
+      expect(map.setView).toHaveBeenCalledWith([51, 3], 12);
+      expect(MockResizeObserver).not.toHaveBeenCalled();
+    });
+
+    it("should defer the view when the container has no dimensions yet", () => {
+      const container = { clientWidth: 0, clientHeight: 0 };
+      let observerCallback;
+      globalThis.ResizeObserver = jest.fn((cb) => {
+        observerCallback = cb;
+        return { observe: jest.fn(), disconnect: jest.fn() };
+      });
+
+      const map = {
+        getContainer: () => container,
+        setView: jest.fn(),
+        invalidateSize: jest.fn()
+      };
+      const config = { x: 51, y: 3, zoom: 12 };
+      const service = new InitialViewRenderService(map, config, {}, {});
+
+      service.setup();
+      expect(map.setView).not.toHaveBeenCalled();
+
+      container.clientWidth = 100;
+      container.clientHeight = 100;
+      container.isConnected = true;
+      observerCallback();
+
+      expect(map.invalidateSize).toHaveBeenCalled();
+      expect(map.setView).toHaveBeenCalledWith([51, 3], 12);
     });
   });
 });


### PR DESCRIPTION
Broke out the removal of the overzealous `InitialViewRenderService.setup()` calls from #205 to a separate PR as requested. I've also added test coverage for the changes as well. Let me know if anything else is needed!