### PR TITLE
Fix live marker updates when history_start is omitted

### DIFF
--- a/src/components/MapCard.js
+++ b/src/components/MapCard.js
@@ -111,7 +111,7 @@ export default class MapCard extends LitElement {
       this.pluginsRenderService.render();
       this.tileLayersService.render();
       this.geoJsonRenderService.render(this.hass);
-      this.entitiesRenderService.render();
+      this.entitiesRenderService.render(this.hass);
       this.initialViewRenderService.render();
 
       if (!this.hasError && this.hadError) {

--- a/src/models/Entity.test.js
+++ b/src/models/Entity.test.js
@@ -211,7 +211,32 @@ describe('Entity class', () => {
       entityConfig.fixedX = 30;
       entityConfig.fixedY = 40;
       expect(entity.latLng).toEqual({ lat: 30, lng: 40 });
-    });    
+    });
+
+    it('follows live hass state after hass is replaced', () => {
+      entityConfig.fixedX = null;
+      entityConfig.fixedY = null;
+      const entity = new Entity(entityConfig, hass, jest.fn(), jest.fn(), jest.fn(), jest.fn(), false);
+
+      expect(entity.latLng.lat).toBe(40.7128);
+      expect(entity.latLng.lng).toBe(-74.0060);
+
+      entity.hass = {
+        ...hass,
+        states: {
+          'test-entity': {
+            attributes: {
+              friendly_name: 'Test Entity',
+              latitude: 51.5074,
+              longitude: -0.1278
+            }
+          }
+        }
+      };
+
+      expect(entity.latLng.lat).toBe(51.5074);
+      expect(entity.latLng.lng).toBe(-0.1278);
+    });
   })
 
   describe('react', () => {

--- a/src/models/EntityHistoryManager.js
+++ b/src/models/EntityHistoryManager.js
@@ -89,12 +89,20 @@ export default class EntityHistoryManager {
       this.currentHistoryEnd = this.entity.config.historyEnd;
     }
 
+    // Only open history/stream when the user actually configured history.
+    // A 10s-ago fallback used to be sent for live marker updates; HA 2026.7+
+    // rejects that start_time, the subscribe fails, and the marker never moves
+    // (see #217). Live position now comes from hass.states on each render.
+    if (!this.hasHistory) {
+      Logger.debug(`[EntityHistoryManager] No history configured for ${this.entity.id}, skipping subscription`);
+      return;
+    }
+
     // Skip the initial subscription when dates will be provided dynamically.
     // The date range manager or linked entity callbacks will call refreshHistory()
     // with the proper dates shortly after init.
     if (!this.entity.config.usingDateRangeManager && !this.entity.config.historyStartEntity) {
-      const historyStart = this.entity.config.historyStart ?? new Date(Date.now() - 10 * 1000);
-      this.subscribeHistory(historyStart, this.entity.config.historyEnd);
+      this.subscribeHistory(this.currentHistoryStart, this.currentHistoryEnd);
     } else {
       Logger.debug(`[EntityHistoryManager] Skipping initial subscription for ${this.entity.id}, waiting for dynamic dates`);
     }
@@ -107,15 +115,20 @@ export default class EntityHistoryManager {
   }
 
   refreshHistory() {
+    if (!this.hasHistory) {
+      return;
+    }
     Logger.debug(`[EntityHistoryManager] Refreshing history for ${this.entity.id}: ${this.currentHistoryStart} -> ${this.currentHistoryEnd}`);
-    this.historyLayerGroup.clearLayers();
+    this.historyLayerGroup?.clearLayers();
     this.subscribeHistory(this.currentHistoryStart, this.currentHistoryEnd);
   }
 
   subscribeHistory(start, end) {
-    if(this.hasHistory) {
-      this.history = new EntityHistory(this.entity.id, this.entity.tooltip, this.entity.config.historyLineColor, this.entity.config.gradualOpacity, this.entity.config.historyShowDots, this.entity.config.historyShowLines);
+    if (!this.hasHistory) {
+      Logger.debug(`[EntityHistoryManager] Skipping history subscription for ${this.entity.id}; no history configured`);
+      return;
     }
+    this.history = new EntityHistory(this.entity.id, this.entity.tooltip, this.entity.config.historyLineColor, this.entity.config.gradualOpacity, this.entity.config.historyShowDots, this.entity.config.historyShowLines);
     this.historyService.subscribe(this.entity.id, start, end, this.react.bind(this), this.entity.config.useBaseEntityOnly);
   }
 

--- a/src/models/EntityHistoryManager.test.js
+++ b/src/models/EntityHistoryManager.test.js
@@ -56,6 +56,41 @@ describe('EntityHistoryManager', () => {
       
       expect(mockOnStateChange).toHaveBeenCalledTimes(2);
     });
+
+    it('should not subscribe to history when history is not configured', () => {
+      const spySubscribe = jest.spyOn(entityHistoryManager.historyService, 'subscribe');
+      entityHistoryManager.entity.config.hasHistory = false;
+      entityHistoryManager.entity.config.usingDateRangeManager = false;
+      entityHistoryManager.entity.config.historyStart = null;
+      entityHistoryManager.entity.config.historyStartEntity = undefined;
+
+      entityHistoryManager.setupListeners();
+
+      expect(spySubscribe).not.toHaveBeenCalled();
+      spySubscribe.mockRestore();
+    });
+
+    it('should subscribe with the configured start, not a 10s fallback, when history is set', () => {
+      const spySubscribe = jest.spyOn(entityHistoryManager.historyService, 'subscribe');
+      const start = new Date('2026-01-01T00:00:00Z');
+      const end = new Date('2026-01-01T01:00:00Z');
+      entityHistoryManager.entity.config.hasHistory = true;
+      entityHistoryManager.entity.config.usingDateRangeManager = false;
+      entityHistoryManager.entity.config.historyStart = start;
+      entityHistoryManager.entity.config.historyEnd = end;
+      entityHistoryManager.entity.config.historyStartEntity = undefined;
+
+      entityHistoryManager.setupListeners();
+
+      expect(spySubscribe).toHaveBeenCalledWith(
+        entity.id,
+        start,
+        end,
+        expect.any(Function),
+        undefined
+      );
+      spySubscribe.mockRestore();
+    });
   });
 
   describe('setHistoryDates', () => {
@@ -88,6 +123,14 @@ describe('EntityHistoryManager', () => {
       const spySubscribe = jest.spyOn(entityHistoryManager.historyService, 'subscribe');
       entityHistoryManager.subscribeHistory(new Date(), new Date());
       expect(spySubscribe).toHaveBeenCalledWith(entity.id, expect.any(Date), expect.any(Date), expect.any(Function), undefined);
+      spySubscribe.mockRestore();
+    });
+
+    it('should not call historyService when history is not configured', () => {
+      const spySubscribe = jest.spyOn(entityHistoryManager.historyService, 'subscribe');
+      entityHistoryManager.entity.config.hasHistory = false;
+      entityHistoryManager.subscribeHistory(new Date(), new Date());
+      expect(spySubscribe).not.toHaveBeenCalled();
       spySubscribe.mockRestore();
     });
   });

--- a/src/services/render/EntitiesRenderService.js
+++ b/src/services/render/EntitiesRenderService.js
@@ -76,8 +76,17 @@ export default class EntitiesRenderService {
 
   }
 
-  async render() {
+  async render(hass) {
+    if (hass) {
+      this.hass = hass;
+    }
     this.entities.forEach((ent) => {
+      // Entity keeps the hass object from setup(); Lovelace replaces hass on
+      // every state change, so without this the marker reads a stale snapshot
+      // and never moves (#217).
+      if (this.hass) {
+        ent.hass = this.hass;
+      }
       ent.update(this.markerClusterGroup);
     });
     this.updateInitialView();

--- a/src/services/render/EntitiesRenderService.test.js
+++ b/src/services/render/EntitiesRenderService.test.js
@@ -7,6 +7,25 @@ describe("EntitiesRenderService", () => {
     it("should have a method", () => {
       expect(new EntitiesRenderService().render).toBeDefined();
     });
+
+    it("pushes the latest hass onto each entity before update", async () => {
+      const focusFollow = new FocusFollowConfig("none");
+      const service = new EntitiesRenderService({}, {}, focusFollow, [], {}, {}, {}, false, false);
+      const firstHass = { id: "old" };
+      const nextHass = { id: "new" };
+      const entity = {
+        hass: firstHass,
+        update: jest.fn(),
+        config: { focusOnFit: false },
+      };
+      service.entities = [entity];
+
+      await service.render(nextHass);
+
+      expect(service.hass).toBe(nextHass);
+      expect(entity.hass).toBe(nextHass);
+      expect(entity.update).toHaveBeenCalled();
+    });
   });
 
   describe("setup", () => {


### PR DESCRIPTION
Fixes #217.

When `history_start` is not set, the card still opened a `history/stream` subscription with a start of **10 seconds ago**. HA 2026.7+ rejects that (`invalid_start_time`). Live movement was supposed to arrive on that stream (`Entity.react` → `_currentLatLng`); when the subscribe fails, the marker never moves.

On top of that, `Entity` kept the `hass` object from `setup()`. Lovelace replaces `hass` on every state change, so even the `hass.states` fallback was reading a stale snapshot. Leaving the view remounts the card, which is why it then jumped.

### Changes
- Subscribe to history only when history is actually configured (`history_start`, a start entity, or the date-range manager). No 10s fallback.
- Pass current `hass` into `EntitiesRenderService.render()` and assign it onto each entity before `update()`, matching how GeoJSON layers already work.

Live position now comes from current entity state. `history_start` is only needed if you want a trail.

### Tests
- No subscribe when history is not configured
- Configured `history_start` is used as-is (not a 10s fallback)
- `Entity.latLng` follows a replaced `hass` object
- Render pushes the latest `hass` onto entities