### PR TITLE
Fix picture markers overlaying auto-generated initials

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Either the name of the `entity` or:
 | `display`              | `marker`                              | `icon`, `state`, `attribute` or `marker`. <br/>`marker` will display the picture if available. <br/>`icon` will display the icon if available, otherwise a label composed of first letters of the entity's name |
 | `picture`              |                                       | Set a custom picture to use on the marker.                                                    |
 | `icon`                 |                                       | Set a custom icon to use if `display` is set to `icon`. e.g. `mdi:cake`                           |
-| `label`                |                                       | Set a custom text label to display on the marker (overrides auto-generated initials). Works with picture overlays.                |
+| `label`                |                                       | Set a custom text label to display on the marker (overrides auto-generated initials). On picture markers, `label` / `prefix` / `suffix` overlay the photo; auto-generated initials do not. |
 | `attribute`            |                                       | Set an attribute to use if `display` is set to `attribute`. e.g. `speed`                |
 | `prefix`            |                                       | Optional prefix for a value if `display` is set to `attribute`                |
 | `suffix`            |                                       | Optional suffix for a value if `display` is set to `attribute`                |

--- a/src/components/MapCardEntityMarker.js
+++ b/src/components/MapCardEntityMarker.js
@@ -1,10 +1,23 @@
 import { LitElement, html, css } from "lit";
 
+/**
+ * Picture markers only get a text overlay when the user asked for one.
+ * Auto-generated initials (title) must not cover entity pictures (#197).
+ * @param {string} prefix
+ * @param {string} suffix
+ * @param {string} label
+ * @returns {boolean}
+ */
+export function shouldOverlayPictureLabel(prefix, suffix, label) {
+  return Boolean(prefix || suffix || (label && String(label).trim()));
+}
+
 export default class MapCardEntityMarker extends LitElement {
   static get properties() {
     return {
       'entityId': {type: String, attribute: 'entity-id'},
       'title': {type: String, attribute: 'title'},
+      'label': {type: String, attribute: 'label'},
       'prefix': {type: String, attribute: 'prefix'},
       'suffix': {type: String, attribute: 'suffix'},
       'tooltip': {type: String, attribute: 'tooltip'},
@@ -48,8 +61,7 @@ export default class MapCardEntityMarker extends LitElement {
 
   _inner() {
     if(this.picture) {
-      // Show picture with optional label overlay
-      const hasLabel = this.title && (this.prefix || this.suffix || this.title.trim());
+      const hasLabel = shouldOverlayPictureLabel(this.prefix, this.suffix, this.label);
       return html`
         <div class="entity-picture" style="background-image: url(${this.picture})"></div>
         ${hasLabel ? html`

--- a/src/components/MapCardEntityMarker.test.js
+++ b/src/components/MapCardEntityMarker.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+jest.mock("lit", () => ({
+  LitElement: class {},
+  html: () => ({}),
+  css: () => "",
+}));
+
+import { shouldOverlayPictureLabel } from "./MapCardEntityMarker.js";
+
+describe("shouldOverlayPictureLabel", () => {
+  it("does not overlay auto-generated initials on a picture", () => {
+    expect(shouldOverlayPictureLabel("", "", "")).toBe(false);
+    expect(shouldOverlayPictureLabel(undefined, undefined, undefined)).toBe(false);
+  });
+
+  it("overlays an explicit label on a picture", () => {
+    expect(shouldOverlayPictureLabel("", "", "Dad")).toBe(true);
+  });
+
+  it("overlays prefix or suffix on a picture", () => {
+    expect(shouldOverlayPictureLabel("~", "", "")).toBe(true);
+    expect(shouldOverlayPictureLabel("", "km", "")).toBe(true);
+  });
+
+  it("ignores a whitespace-only label", () => {
+    expect(shouldOverlayPictureLabel("", "", "   ")).toBe(false);
+  });
+});

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -323,6 +323,7 @@ export default class Entity {
           <map-card-entity-marker
             entity-id="${this.id}"
             title="${this.title}"
+            label="${this.config.label ?? ""}"
             prefix="${this.config.prefix}"
             suffix="${this.config.suffix}"
             tooltip="${this.tooltip}"


### PR DESCRIPTION
Fixes #197.

v1.14 (#172) added a label banner on picture markers. The condition was:

\`\`\`js
const hasLabel = this.title && (this.prefix || this.suffix || this.title.trim());
\`\`\`

\`title\` is the auto-generated initials (e.g. \`KL\`), so every entity picture got initials drawn over the photo. That matches the double-\`KL\` reports vs v1.13.1.

### Changes
- Overlay text on a picture only when the user set \`prefix\`, \`suffix\`, or \`label\`.
- Pass \`label\` through from entity config so an explicit label still overlays the photo (as documented).
- README note clarifying the picture-overlay behaviour.

\`display: icon\` / \`state\` / \`attribute\` are unchanged.