### PR TITLE
Fix unknown-position crashes, GeoJSON-vs-history, and trail joint opacity

### DIFF
--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -97,7 +97,7 @@ export default class Entity {
 
   /** @returns {{[key: string]: object}} */
   get attributes() {
-    return this.currentTimelineEntry?.state.a ?? this.hass.states[this.id].attributes;
+    return this.currentTimelineEntry?.state.a ?? this.hass.states[this.id]?.attributes ?? {};
   }
 
   /** 
@@ -133,22 +133,28 @@ export default class Entity {
     let subTrackerIds = this.attributes.device_trackers ?? []
     for (let t = 0; t < subTrackerIds.length; t++) {
       const entity = this.hass.states[subTrackerIds[t]];
-      if (entity.attributes.latitude && entity.attributes.longitude) {
+      if (entity?.attributes?.latitude && entity.attributes.longitude) {
         return new LatLng(entity.attributes.latitude, entity.attributes.longitude);
       }
     }
 
-    Logger.warn("Entity: " + this.id + " has no latitude & longitude");
+    if (this._lastSetLatLng) {
+      return this._lastSetLatLng;
+    }
+
     if (this.config.fallbackX && this.config.fallbackY) {
       return new LatLng(this.config.fallbackX, this.config.fallbackY);
     }
-    Logger.error("Entity: " + this.id + " has no fallback latitude & longitude");
-    throw Error("Entity: " + this.id + " has no latitude & longitude and no fallback configured")
+
+    Logger.warn("Entity: " + this.id + " has no latitude & longitude; skipping marker");
+    return null;
   }
 
   setup(clusterGroup = null) {
-    // Only add marker if GeoJSON is not configured to hide it
-    if (!this.config.geoJsonConfig.hideMarker) {
+    // Only add marker if GeoJSON is not configured to hide it and we have a
+    // position. Missing/unknown coords used to throw here and abort the rest
+    // of the card (#91, #173).
+    if (!this.config.geoJsonConfig?.hideMarker && this.latLng) {
       this.marker = this.createMapMarker();
 
       // Bind distance tooltip if configured
@@ -348,6 +354,18 @@ export default class Entity {
   }
 
   async update(clusterGroup = null) {
+    // Entity recovered a position after being unknown/unavailable.
+    if (!this.marker && !this.config.geoJsonConfig?.hideMarker && this.latLng) {
+      this.marker = this.createMapMarker();
+      if (clusterGroup) {
+        clusterGroup.addLayer(this.marker);
+      } else {
+        this.marker.addTo(this.map);
+      }
+      this._lastSetLatLng = this.latLng;
+      this._currentPlaceIcon = this.placeIcon;
+    }
+
     // Only update marker if it exists (not hidden by GeoJSON config)
     if (this.marker) {
       // Recreate the marker when the display title changes (state/attribute
@@ -382,6 +400,7 @@ export default class Entity {
   updateMarkerPosition() {
     if (!this.marker) return;
     const newLatLng = this.latLng;
+    if (!newLatLng) return;
     const threshold = this.config.positionUpdateThreshold;
     // Update position only if it has changed significantly (configurable threshold in meters)
     if (!this._lastSetLatLng || this.map.distance(this._lastSetLatLng, newLatLng) > threshold) {

--- a/src/models/Entity.test.js
+++ b/src/models/Entity.test.js
@@ -190,13 +190,35 @@ describe('Entity class', () => {
       expect(entity.latLng.lng).toBe(1);
     });
   
-    it('throws an error if no coordinates can be found', () => {
+    it('returns null if no coordinates can be found, instead of throwing', () => {
       entityConfig.fallbackX = null;
       entityConfig.fallbackY = null;
       hass.states['test-entity'].attributes = {};
 
       const entity = new Entity(entityConfig, hass, jest.fn(), jest.fn(), jest.fn(), jest.fn(), false);
-      expect(() => entity.latLng).toThrow("Entity: test-entity has no latitude & longitude and no fallback configured");
+      expect(entity.latLng).toBeNull();
+    });
+
+    it('keeps the last drawn position when the entity becomes unknown', () => {
+      entityConfig.fallbackX = null;
+      entityConfig.fallbackY = null;
+      hass.states['test-entity'].attributes = { latitude: 30, longitude: 40 };
+      const entity = new Entity(entityConfig, hass, jest.fn(), jest.fn(), jest.fn(), jest.fn(), false);
+      entity._lastSetLatLng = entity.latLng;
+
+      hass.states['test-entity'].attributes = {};
+      expect(entity.latLng.lat).toBe(30);
+      expect(entity.latLng.lng).toBe(40);
+    });
+
+    it('tolerates a missing linked device_tracker', () => {
+      entityConfig.fallbackX = null;
+      entityConfig.fallbackY = null;
+      hass.states['test-entity'].attributes = {
+        device_trackers: ['device_tracker.gone']
+      };
+      const entity = new Entity(entityConfig, hass, jest.fn(), jest.fn(), jest.fn(), jest.fn(), false);
+      expect(entity.latLng).toBeNull();
     });    
 
     it('returns the current latLng if set', () => {

--- a/src/models/EntityHistory.js
+++ b/src/models/EntityHistory.js
@@ -86,6 +86,9 @@ export default class EntityHistory {
             color: this.color,
             opacity,
             interactive: false,
+            // Round caps from adjacent segments stack on the shared vertex
+            // and make joints darker than the segments (#164).
+            lineCap: 'butt',
           })
         );
       }

--- a/src/models/EntityHistory.test.js
+++ b/src/models/EntityHistory.test.js
@@ -119,7 +119,8 @@ describe('EntityHistory', () => {
       expect(spyPolyline).toHaveBeenCalledWith([ [51.5, -0.1], [51.6, -0.2] ], expect.objectContaining({
         color: 'red',
         opacity: 0.5,
-        interactive: false
+        interactive: false,
+        lineCap: 'butt',
       }));
 
       spyPolyline.mockRestore();
@@ -143,7 +144,8 @@ describe('EntityHistory', () => {
       expect(spyPolyline).toHaveBeenCalledWith([ [51.5, -0.1], [51.6, -0.2] ], expect.objectContaining({
         color: 'red',
         opacity: 1,
-        interactive: false
+        interactive: false,
+        lineCap: 'butt',
       }));
 
       spyPolyline.mockRestore();

--- a/src/models/GeoJson.js
+++ b/src/models/GeoJson.js
@@ -62,7 +62,13 @@ export default class GeoJson {
    * @returns {object|null}
    */
   _getGeoJsonData() {
-    const attributeValue = this.entity.attributes[this.config.attribute];
+    // Always read live hass state. Entity.attributes prefers the latest
+    // history timeline entry, which typically only has lat/lng — so once
+    // history loads the GeoJSON attribute disappears and the layer is
+    // cleared (#204).
+    const liveAttrs = this.entity.hass?.states?.[this.entity.id]?.attributes;
+    const attrs = liveAttrs ?? this.entity.attributes ?? {};
+    const attributeValue = attrs[this.config.attribute];
 
     if (!attributeValue) {
       Logger.debug(`[GeoJson]: No data found in attribute '${this.config.attribute}' for ${this.entity.id}`);

--- a/src/models/GeoJson.test.js
+++ b/src/models/GeoJson.test.js
@@ -190,6 +190,30 @@ describe('GeoJson', () => {
 
       expect(L.geoJSON).not.toHaveBeenCalled();
     });
+
+    it('reads GeoJSON from live hass state even when history attributes have no geometry', () => {
+      const geoJsonData = {
+        type: 'Polygon',
+        coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]]
+      };
+
+      mockEntity.attributes = { latitude: 1, longitude: 2 };
+      mockEntity.id = 'zone.home';
+      mockEntity.hass = {
+        states: {
+          'zone.home': {
+            attributes: { zone_data: geoJsonData }
+          }
+        }
+      };
+
+      const config = new GeoJsonConfig('zone_data', '#ff0000');
+      const geoJson = new GeoJson(config, mockEntity);
+
+      geoJson.setup();
+
+      expect(L.geoJSON).toHaveBeenCalledWith(geoJsonData, expect.any(Object));
+    });
   });
 
   describe('_createTooltipContent', () => {

--- a/src/services/render/EntitiesRenderService.js
+++ b/src/services/render/EntitiesRenderService.js
@@ -140,10 +140,14 @@ export default class EntitiesRenderService {
       // Entity keeps the hass object from setup(); Lovelace replaces hass on
       // every state change, so without this the marker reads a stale snapshot
       // and never moves (#217).
-      if (this.hass) {
-        ent.hass = this.hass;
+      try {
+        if (this.hass) {
+          ent.hass = this.hass;
+        }
+        ent.update(this.markerClusterGroup);
+      } catch (e) {
+        Logger.error("Entity: " + ent.id + " failed to update", e);
       }
-      ent.update(this.markerClusterGroup);
     });
     this.updateInitialView();
   }


### PR DESCRIPTION
Three small, isolated bug fixes.

### Unknown / unavailable position (#91, #173)
\`Entity.latLng\` threw when there were no coordinates and no fallback. \`setup()\` caught that; \`render()\` / \`update()\` did not, so one missing entity aborted the whole card (and could freeze the tab).

Now we keep the last drawn position, skip the marker if we have never had coords, recreate it if the entity recovers, and isolate per-entity update failures.

### GeoJSON disappears when history loads (#204)
\`Entity.attributes\` prefers the latest history timeline entry. Those entries typically only have lat/lng, so \`GeoJson.update()\` removed the layer and found nothing to put back.

GeoJSON is now read from live \`hass.states[id].attributes\`.

### Dark joints on \`gradual_opacity\` trails (#164)
Adjacent polylines share a vertex. Leaflet's default round line cap draws both caps on top of each other. History lines now use \`lineCap: 'butt'\`.