### PR TITLE
Project wide babel config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,0 @@
-{
-  "presets": [
-    ["@babel/preset-env", {
-      "modules": "commonjs"
-    }]
-  ]
-}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  presets: [
+    ["@babel/preset-env", {
+      modules: "commonjs"
+    }]
+  ]
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
       '^.+\\.js$': 'babel-jest',
     },
     transformIgnorePatterns: [
-      "/node_modules/(?!(@open-wc|lit|@esm-bundle)).+\\.js$"
+      "/node_modules/(?!(@open-wc|@lit|lit|@esm-bundle)).+\\.js$"
     ],
     moduleFileExtensions: ['js', 'json'],
     testEnvironment: 'jsdom',


### PR DESCRIPTION
Change file-relative .babelrc with project wide babel config

I've started checking things which can be improved, performance wise. And this is a first thing it (also) did. More to come.

Check if it makes sense, if not, reject.

**Summary (AI)**
.babelrc was Babel's config file for this project — it tells Babel to run @babel/preset-env so modern JS syntax gets transpiled to something Jest/Node can execute (this project doesn't use TypeScript, so this is the only compile step test files go through).

The problem: .babelrc is a file-relative config format — Babel only applies it to files within the same npm package as the config file itself. It does not apply across a node_modules package boundary. So when MapCard.js pulled in lit (and lit pulled in @lit/reactive-element), those files live in their own package (node_modules/lit/, with its own package.json), and Babel silently skipped transforming them — even though jest.config.js's transformIgnorePatterns said they should be transformed. The raw import/export syntax then hit Node's CommonJS require() and blew up with Cannot use import statement outside a module.

babel.config.js is the "project-wide" config format — same options, but it applies regardless of package boundaries, which is exactly what's needed to transform lit/@lit inside node_modules. That's why I deleted .babelrc and replaced it with an equivalent babel.config.js; the preset-env settings are unchanged, this only fixes which files the config applies to.

The new diagnostic (babel.config.js "may be converted to an ES module") is just an editor/TS suggestion, not an error — Babel config files are loaded via Node's CJS require by convention (same as this project's existing jest.config.js), so module.exports is correct here and I'd leave it as-is.